### PR TITLE
Fix/overview screen implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -122,6 +122,8 @@ dependencies {
     // Play Services Auth (for Google Sign-In)
     implementation(libs.play.services.auth.v2050)
 
+    implementation(libs.coil.compose)
+
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/app/src/androidTest/java/com/android/brewr/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/overview/OverviewTest.kt
@@ -29,7 +29,8 @@ class OverviewScreenTest {
   private val journey =
       Journey(
           uid = "journey1",
-          imageUrl = "https://example.com/image.jpg",
+          imageUrl =
+              "https://firebasestorage.googleapis.com/v0/b/brewr-epfl.appspot.com/o/images%2Fff3cdd66-87c7-40a9-af5e-52f98d8374dc?alt=media&token=6257d10d-e770-44c7-b038-ea8c8a3eedb2",
           description = "A wonderful coffee journey.",
           coffeeShopName = "Starbucks",
           coffeeOrigin = CoffeeOrigin.BRAZIL,
@@ -62,6 +63,13 @@ class OverviewScreenTest {
     // Assert that the 'Add' and 'Account' buttons exist
     composeTestRule.onNodeWithTag("addButton").assertIsDisplayed().assertHasClickAction()
     composeTestRule.onNodeWithTag("accountButton").assertIsDisplayed().assertHasClickAction()
+  }
+
+  @Test
+  fun exploreScreen_displayCorrectly() {
+    composeTestRule.setContent { OverviewScreen(listJourneysViewModel, navigationActions) }
+    composeTestRule.onNodeWithTag("Explore").performClick()
+    composeTestRule.onNodeWithTag("exploreContent").assertIsDisplayed()
   }
 
   @Test
@@ -105,7 +113,6 @@ class OverviewScreenTest {
     // Wait for UI state to settle
     composeTestRule.waitForIdle() // or mainClock.advanceUntilIdle()
 
-    composeTestRule.onNodeWithText("Starbucks").assertIsDisplayed()
     composeTestRule.onNodeWithTag("journeyListItem").assertIsDisplayed()
     // Perform a click on the first item in the list
     composeTestRule.onAllNodesWithTag("journeyListItem")[0].performClick()

--- a/app/src/main/java/com/android/brewr/ui/overview/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Explore.kt
@@ -1,0 +1,18 @@
+package com.android.brewr.ui.overview
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+
+@Composable
+fun ExploreScreen() {
+  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(
+        modifier = Modifier.testTag("exploreContent"),
+        text = "Explore content here, not yet implemented.")
+  }
+}

--- a/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
@@ -1,14 +1,20 @@
 package com.android.brewr.ui.overview
 
 import android.widget.Toast
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -18,6 +24,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import com.android.brewr.model.journey.Journey
 import com.android.brewr.model.journey.ListJourneysViewModel
 
 @Composable
@@ -46,6 +55,33 @@ fun GalleryScreen(
   } else {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Text(modifier = Modifier.testTag("emptyJourneyPrompt"), text = "You have no Journey yet.")
+    }
+  }
+}
+
+@Composable
+fun JourneyItem(journey: Journey, onClick: () -> Unit) {
+  Card(
+      modifier =
+          Modifier.testTag("journeyListItem")
+              .fillMaxWidth()
+              .padding(vertical = 4.dp)
+              .clickable(onClick = onClick),
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+      Image(
+          painter =
+              rememberAsyncImagePainter(
+                  ImageRequest.Builder(LocalContext.current)
+                      .data(journey.imageUrl)
+                      .apply(
+                          block =
+                              fun ImageRequest.Builder.() {
+                                crossfade(true)
+                              })
+                      .build()),
+          contentDescription = "Selected Image",
+          modifier = Modifier.size(120.dp))
     }
   }
 }

--- a/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
@@ -1,0 +1,51 @@
+package com.android.brewr.ui.overview
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.brewr.model.journey.ListJourneysViewModel
+
+@Composable
+fun GalleryScreen(
+    listJourneysViewModel: ListJourneysViewModel =
+        viewModel(factory = ListJourneysViewModel.Factory),
+    padding: PaddingValues,
+) {
+  val journeys = listJourneysViewModel.journeys.collectAsState().value
+  val context = LocalContext.current
+
+  if (journeys.isNotEmpty()) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        modifier = Modifier.fillMaxSize().padding(padding),
+        contentPadding = PaddingValues(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      items(journeys) { journey ->
+        JourneyItem(journey = journey) {
+          Toast.makeText(context, "Feature not yet developed", Toast.LENGTH_SHORT).show()
+        }
+      }
+    }
+  } else {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Text(modifier = Modifier.testTag("emptyJourneyPrompt"), text = "You have no Journey yet.")
+    }
+  }
+}

--- a/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Gallery.kt
@@ -81,7 +81,7 @@ fun JourneyItem(journey: Journey, onClick: () -> Unit) {
                               })
                       .build()),
           contentDescription = "Selected Image",
-          modifier = Modifier.size(120.dp))
+          modifier = Modifier.testTag("journeyImage").size(120.dp))
     }
   }
 }

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -19,10 +19,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.compose.rememberNavController
 import com.android.brewr.model.journey.ListJourneysViewModel
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Screen
@@ -114,14 +112,4 @@ fun SubNavigationButton(text: String, isSelected: Boolean = false, onClick: () -
                   RoundedCornerShape(8.dp))
               .padding(8.dp)
               .testTag(text))
-}
-
-@Preview(showBackground = true)
-@Composable
-fun OverviewScreenPreview() {
-  val navController = rememberNavController()
-  val navigationActions = NavigationActions(navController)
-  OverviewScreen(
-      listJourneysViewModel = viewModel(factory = ListJourneysViewModel.Factory),
-      navigationActions = navigationActions)
 }

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -24,7 +23,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
-import com.android.brewr.model.journey.Journey
 import com.android.brewr.model.journey.ListJourneysViewModel
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Screen
@@ -116,21 +114,6 @@ fun SubNavigationButton(text: String, isSelected: Boolean = false, onClick: () -
                   RoundedCornerShape(8.dp))
               .padding(8.dp)
               .testTag(text))
-}
-
-@Composable
-fun JourneyItem(journey: Journey, onClick: () -> Unit) {
-  Card(
-      modifier =
-          Modifier.testTag("journeyListItem")
-              .fillMaxWidth()
-              .padding(vertical = 4.dp)
-              .clickable(onClick = onClick),
-  ) {
-    Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-      Text(text = journey.coffeeShopName) // Placeholder for coffee shop name
-    }
-  }
 }
 
 @Preview(showBackground = true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
-agp = "8.7.0"
+agp = "8.7.1"
 biometric = "1.2.0"
+coilCompose = "2.1.0"
 coreKtxVersion = "1.13.1"
 credentials = "1.5.0-alpha05"
 credentialsPlayServicesAuth = "1.0.0"
@@ -36,6 +37,7 @@ espressoIntents = "3.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 firebase-bom-v3200 = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBomVersion" }
 google-firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
Corresponding issue: https://github.com/BrewR-EPFL/BrewR/issues/58

This PR introduces the fix of the OverviewScreen, which allows the journeys card to display the corresponding images. This includes a  the creation of two now screens, GalleryScreen and ExploreScreen.
Additionally, test tags have been added to the UI components to facilitate UI testing.

The following composables have been created:

GalleryScreen: The main composable for displaying journeys. It includes a grip (2x?, depending on the number of journeys logged).

ExploreScreen: Not yet implemented.

The following components have been modified:
- LazyColumn is replaced by LazyVerticalGrid of parameter 2.

- JourneyItem: Use rememberAsyncImagePainter to display the image of the journey


overviewScreen: Tag for the main container of the overview screen.
appTitle: Tag for the app title displayed in the top app bar.
addButton: Tag for the button that triggers the add action.
accountButton: Tag for the button that navigates to the user profile.
Gallery: Tag for the sub-navigation button representing the "Gallery" section.
Explore: Tag for the sub-navigation button representing the "Explore" section.
emptyJourneyPrompt: Tag for the text prompt displayed when there are no journeys.
journeyListItem: Tag for each journey item displayed in the gallery.
journeyImage: Tag for the image displayed in each journey item.
exploreContent: Tag for the text displayed in the Explore screen, indicating the content is not yet implemented.