### PR TITLE
Test(unit): write units test for JourneysRepository, ListJourneysViewModel and NavigationActions

### DIFF
--- a/app/src/test/java/com/android/brewr/model/journey/JourneysRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/brewr/model/journey/JourneysRepositoryFirestoreTest.kt
@@ -1,0 +1,240 @@
+package com.android.brewr.model.journey
+
+import android.os.Looper
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.FirebaseApp
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.*
+import junit.framework.TestCase.fail
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class JourneysRepositoryFirestoreTest {
+
+  @Mock private lateinit var mockFirestore: FirebaseFirestore
+  @Mock private lateinit var mockCollectionReference: CollectionReference
+  @Mock private lateinit var mockDocumentReference: DocumentReference
+  @Mock private lateinit var mockQuerySnapshot: QuerySnapshot
+
+  private lateinit var journeysRepository: JourneysRepositoryFirestore
+
+  private val journey =
+      Journey(
+          uid = "journey1",
+          imageUrl = "https://example.com/image.jpg",
+          description = "A wonderful coffee journey.",
+          coffeeShopName = "Starbucks",
+          coffeeOrigin = CoffeeOrigin.BRAZIL,
+          brewingMethod = BrewingMethod.POUR_OVER,
+          coffeeTaste = CoffeeTaste.NUTTY,
+          coffeeRate = CoffeeRate.ONE,
+          date = Timestamp.now(),
+          location = "Lausanne")
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+    // Initialize Firebase if necessary
+    if (FirebaseApp.getApps(ApplicationProvider.getApplicationContext()).isEmpty()) {
+      FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+    }
+    mockFirestore = mock(FirebaseFirestore::class.java)
+    journeysRepository = JourneysRepositoryFirestore(mockFirestore)
+
+    `when`(mockFirestore.collection(org.mockito.kotlin.any())).thenReturn(mockCollectionReference)
+
+    `when`(mockCollectionReference.document(org.mockito.kotlin.any()))
+        .thenReturn(mockDocumentReference)
+    `when`(mockCollectionReference.document()).thenReturn(mockDocumentReference)
+  }
+
+  @Test
+  fun testGetNewUid() {
+    `when`(mockDocumentReference.id).thenReturn("1")
+    val uid = journeysRepository.getNewUid()
+    assert(uid == "1")
+  }
+
+  @Test
+  fun getJourneys_callsDocuments() {
+    // Ensure that mockToDoQuerySnapshot is properly initialized and mocked
+    `when`(mockCollectionReference.get()).thenReturn(Tasks.forResult(mockQuerySnapshot))
+
+    // Ensure the QuerySnapshot returns a list of mock DocumentSnapshots
+    `when`(mockQuerySnapshot.documents).thenReturn(listOf())
+
+    // Call the method under test
+    journeysRepository.getJourneys(
+        onSuccess = {
+          // Do nothing; we just want to verify that the 'documents' field was accessed
+        },
+        onFailure = { fail("Failure callback should not be called") })
+    // Verify that the 'documents' field was accessed
+    verify(org.mockito.kotlin.timeout(100)) { (mockQuerySnapshot).documents }
+  }
+
+  @Test
+  fun addJourney_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(org.mockito.kotlin.any()))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    // This test verifies that when we add a new ToDo, the Firestore `collection()` method is
+    // called.
+    journeysRepository.addJourney(journey, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Ensure Firestore collection method was called to reference the "ToDos" collection
+    verify(mockDocumentReference).set(org.mockito.kotlin.any())
+  }
+
+  @Test
+  fun updateJourney_shouldCallDocumentReferenceDelete() {
+    `when`(mockDocumentReference.set(org.mockito.kotlin.any()))
+        .thenReturn(Tasks.forResult(null)) // Simulate success
+
+    journeysRepository.updateJourney(journey, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
+
+    verify(mockDocumentReference).set(org.mockito.kotlin.any())
+  }
+
+  @Test
+  fun deleteJourneyById_shouldCallDocumentReferenceDelete() {
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forResult(null))
+
+    journeysRepository.deleteJourneyById("1", onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
+
+    verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun documentToJourneyConvertsDocumentSnapshotToJourney() {
+    // Arrange
+    val documentSnapshot = mock<DocumentSnapshot>()
+
+    whenever(documentSnapshot.id).thenReturn("uid1")
+    whenever(documentSnapshot.getString("imageUrl")).thenReturn("http://image1.url")
+    whenever(documentSnapshot.getString("description")).thenReturn("desc1")
+    whenever(documentSnapshot.getString("coffeeShopName")).thenReturn("Shop1")
+    whenever(documentSnapshot.getString("coffeeOrigin")).thenReturn("BRAZIL")
+    whenever(documentSnapshot.getString("brewingMethod")).thenReturn("FRENCH_PRESS")
+    whenever(documentSnapshot.getString("coffeeTaste")).thenReturn("BITTER")
+    whenever(documentSnapshot.getString("coffeeRate")).thenReturn("ONE")
+    whenever(documentSnapshot.getTimestamp("date")).thenReturn(mock())
+    whenever(documentSnapshot.getString("location")).thenReturn("City1")
+
+    // Access the private method using reflection
+    val method =
+        JourneysRepositoryFirestore::class
+            .java
+            .getDeclaredMethod("documentTojourney", DocumentSnapshot::class.java)
+    method.isAccessible = true // Make it accessible
+    val journey = method.invoke(journeysRepository, documentSnapshot) as Journey
+
+    // Assert
+    assertNotNull(journey)
+    assertEquals("uid1", journey.uid)
+    assertEquals("http://image1.url", journey.imageUrl)
+    assertEquals("desc1", journey.description)
+    assertEquals("Shop1", journey.coffeeShopName)
+    assertEquals(CoffeeOrigin.BRAZIL, journey.coffeeOrigin)
+    assertEquals(BrewingMethod.FRENCH_PRESS, journey.brewingMethod)
+    assertEquals(CoffeeTaste.BITTER, journey.coffeeTaste)
+    assertEquals(CoffeeRate.ONE, journey.coffeeRate)
+    assertNotNull(journey.date)
+    assertEquals("City1", journey.location)
+  }
+
+  @Test
+  fun documentToJourneyException() {
+    // Arrange
+    val documentSnapshot = mock<DocumentSnapshot>()
+
+    // Mock the documentSnapshot to return an invalid value for coffeeOrigin
+    // This will cause CoffeeOrigin.valueOf() to throw an exception
+    whenever(documentSnapshot.getString("coffeeOrigin")).thenReturn("INVALID_ORIGIN")
+
+    // Mock static Log method using mockStatic from mockito-inline
+    val logMock: MockedStatic<Log> = mockStatic(Log::class.java)
+
+    // Use reflection to access the private method
+    val method =
+        JourneysRepositoryFirestore::class
+            .java
+            .getDeclaredMethod("documentTojourney", DocumentSnapshot::class.java)
+    method.isAccessible = true
+
+    // Create an instance of the repository
+    val repository = JourneysRepositoryFirestore(mock())
+    val journey = method.invoke(repository, documentSnapshot) as Journey?
+    assertNull(journey) // Expecting null due to the exception being thrown
+
+    // Verify that Log.e was called with the correct parameters
+    logMock.verify {
+      Log.e(
+          eq("JourneysRepositoryFirestore"),
+          eq("Error converting document to Journey"),
+          any<Exception>())
+    }
+
+    // Clean up the static mock after use
+    logMock.close()
+  }
+
+  @Test
+  fun initCallsOnSuccess() {
+    // Arrange
+    val firebaseAuthMock = mock<FirebaseAuth>()
+    val firebaseUserMock = mock<FirebaseUser>()
+
+    // Mock Firebase Auth static methods
+    val firebaseAuthStaticMock: MockedStatic<FirebaseAuth> = mockStatic(FirebaseAuth::class.java)
+
+    // Mock getting the auth instance and its behavior
+    whenever(FirebaseAuth.getInstance()).thenReturn(firebaseAuthMock)
+    whenever(firebaseAuthMock.currentUser).thenReturn(firebaseUserMock) // Simulate a signed-in user
+
+    val onSuccess: () -> Unit = mock()
+
+    // Create the repository
+    val repository = JourneysRepositoryFirestore(mock())
+
+    // Act
+    repository.init(onSuccess)
+
+    // Capture and simulate triggering the AuthStateListener
+    argumentCaptor<FirebaseAuth.AuthStateListener>().apply {
+      verify(firebaseAuthMock).addAuthStateListener(capture())
+      firstValue.onAuthStateChanged(firebaseAuthMock)
+    }
+
+    // Assert
+    verify(onSuccess).invoke() // Ensure onSuccess is called
+
+    // Clean up static mock
+    firebaseAuthStaticMock.close()
+  }
+}

--- a/app/src/test/java/com/android/brewr/model/journey/ListJourneysViewModelTest.kt
+++ b/app/src/test/java/com/android/brewr/model/journey/ListJourneysViewModelTest.kt
@@ -1,0 +1,74 @@
+package com.android.brewr.model.journey
+
+import com.google.firebase.Timestamp
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+
+class ListJourneysViewModelTest {
+  private lateinit var journeysRepository: JourneysRepository
+  private lateinit var listJourneysViewModel: ListJourneysViewModel
+
+  private val journey =
+      Journey(
+          uid = "journey1",
+          imageUrl = "https://example.com/image.jpg",
+          description = "A wonderful coffee journey.",
+          coffeeShopName = "Starbucks",
+          coffeeOrigin = CoffeeOrigin.BRAZIL,
+          brewingMethod = BrewingMethod.POUR_OVER,
+          coffeeTaste = CoffeeTaste.NUTTY,
+          coffeeRate = CoffeeRate.ONE,
+          date = Timestamp.now(),
+          location = "Lausanne")
+
+  @Before
+  fun setUp() {
+    journeysRepository = mock(JourneysRepository::class.java)
+    listJourneysViewModel = ListJourneysViewModel(journeysRepository)
+  }
+
+  @Test
+  fun getNewUid() {
+    `when`(journeysRepository.getNewUid()).thenReturn("uid")
+    assertThat(listJourneysViewModel.getNewUid(), `is`("uid"))
+  }
+
+  @Test
+  fun getJourneysCallsRepository() {
+    listJourneysViewModel.getJourneys()
+    verify(journeysRepository).getJourneys(any(), any())
+  }
+
+  @Test
+  fun addJourneyCallsRepository() {
+    listJourneysViewModel.addJourney(journey)
+    verify(journeysRepository).addJourney(eq(journey), any(), any())
+  }
+
+  @Test
+  fun updateJourneyCallsRepository() {
+    listJourneysViewModel.updateJourney(journey)
+    verify(journeysRepository).updateJourney(eq(journey), any(), any())
+  }
+
+  @Test
+  fun deleteJourneyCallsRepository() {
+    listJourneysViewModel.deleteJourneyById(journey.uid)
+    verify(journeysRepository).deleteJourneyById(eq(journey.uid), any(), any())
+  }
+
+  @Test
+  fun selectJourney() {
+    listJourneysViewModel.selectJourney(journey)
+    val selected = listJourneysViewModel.selectedJourney.value
+    assertEquals(journey, selected)
+  }
+}

--- a/app/src/test/java/com/android/brewr/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/android/brewr/ui/navigation/NavigationActionsTest.kt
@@ -1,0 +1,114 @@
+package com.android.brewr.ui.navigation
+
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
+import androidx.navigation.PopUpToBuilder
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+class NavigationActionsTest {
+
+  private lateinit var navigationDestination: NavDestination
+  private lateinit var navHostController: NavHostController
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    navigationDestination = mock(NavDestination::class.java)
+    navHostController = mock(NavHostController::class.java)
+    navigationActions = NavigationActions(navHostController)
+  }
+
+  @Test
+  fun navigateToCallsController() {
+    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+    verify(navHostController).navigate(eq(Route.OVERVIEW), any<NavOptionsBuilder.() -> Unit>())
+
+    navigationActions.navigateTo(Screen.OVERVIEW)
+    verify(navHostController).navigate(Screen.OVERVIEW)
+  }
+
+  @Test
+  fun goBackCallsController() {
+    navigationActions.goBack()
+    verify(navHostController).popBackStack()
+  }
+
+  @Test
+  fun currentRouteWorksWithDestination() {
+    `when`(navHostController.currentDestination).thenReturn(navigationDestination)
+    `when`(navigationDestination.route).thenReturn(Route.OVERVIEW)
+
+    assertThat(navigationActions.currentRoute(), `is`(Route.OVERVIEW))
+  }
+
+  @Test
+  fun navigateToPopUpToCorrect() {
+    // Mock the NavGraph and NavDestination
+    val mockGraph = mock<NavGraph>()
+    val mockStartDestination = mock<NavDestination>()
+
+    // Setup return values for the mock graph and start destination
+    whenever(navHostController.graph).thenReturn(mockGraph)
+    whenever(mockGraph.findStartDestination()).thenReturn(mockStartDestination)
+    whenever(mockStartDestination.id).thenReturn(123)
+
+    // Capture the lambda passed to navigate() using argumentCaptor
+    val navOptionsCaptor = argumentCaptor<NavOptionsBuilder.() -> Unit>()
+
+    // Use doNothing() to mock the navigate method
+    doNothing()
+        .whenever(navHostController)
+        .navigate(eq(TopLevelDestinations.OVERVIEW.route), navOptionsCaptor.capture())
+
+    // Call the method under test: navigating to the Overview destination
+    navigationActions.navigateTo(TopLevelDestinations.OVERVIEW)
+
+    // Verify that navigate() was called with the correct route and lambda
+    verify(navHostController)
+        .navigate(eq(TopLevelDestinations.OVERVIEW.route), any<NavOptionsBuilder.() -> Unit>())
+
+    // Simulate execution of the captured lambda to verify popUpTo and other options
+    val capturedLambda = navOptionsCaptor.firstValue
+    val mockNavOptionsBuilder = mock<NavOptionsBuilder>()
+    capturedLambda.invoke(mockNavOptionsBuilder)
+
+    // Verify the interactions inside the lambda block
+    val popUpToCaptor = argumentCaptor<Int>()
+    val popUpToLambdaCaptor = argumentCaptor<PopUpToBuilder.() -> Unit>()
+
+    // Capture the popUpTo invocation and verify its arguments
+    verify(mockNavOptionsBuilder).popUpTo(popUpToCaptor.capture(), popUpToLambdaCaptor.capture())
+
+    // Check that popUpTo was called with the correct start destination ID
+    assert(popUpToCaptor.firstValue == 123)
+
+    // Simulate execution of the popUpTo lambda and verify its logic
+    val popUpToLambda = popUpToLambdaCaptor.firstValue
+    val mockPopUpToBuilder = mock<PopUpToBuilder>()
+    popUpToLambda.invoke(mockPopUpToBuilder)
+
+    // Verify the lambda's internal behavior
+    verify(mockPopUpToBuilder).saveState = eq(true)
+    verify(mockPopUpToBuilder).inclusive = eq(true)
+
+    // Verify the other options set in the lambda
+    verify(mockNavOptionsBuilder).launchSingleTop = eq(true)
+
+    // Verify that restoreState is only set when the route is not AUTH
+    verify(mockNavOptionsBuilder).restoreState = eq(true)
+  }
+}


### PR DESCRIPTION
This PR adds tests for **JourneysRepositoryFirestoreTest.kt**, **ListJourneysViewModelTest.kt**, and **NavigationActionsTest.kt** to the main branch.

During Sprint 1, we weren't aware that code and tests should be included in the same PR. As a result, we created PRs for the features alone and pushed them to the main branch without corresponding tests. This led to significantly lower overall line coverage in SonarCloud.

This PR addresses that oversight by adding tests for the last three untested files in the main branch, which will improve our overall test coverage.