### PR TITLE
Develop/display real data on explore screen

### DIFF
--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -1,5 +1,6 @@
 package com.android.brewr.ui
 
+import android.Manifest
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -14,6 +15,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
 import com.android.brewr.model.journey.BrewingMethod
 import com.android.brewr.model.journey.CoffeeOrigin
 import com.android.brewr.model.journey.CoffeeRate
@@ -41,6 +43,12 @@ import org.mockito.Mockito.`when`
 @RunWith(AndroidJUnit4::class)
 class E2ETest {
   @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule
+  val fineLocationPermissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
+  @get:Rule
+  val coarseLocationPermissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION)
 
   private lateinit var repositoryMock: JourneysRepository
   private lateinit var listJourneysViewModel: ListJourneysViewModel

--- a/app/src/androidTest/java/com/android/brewr/ui/overview/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/overview/MapScreenTest.kt
@@ -7,6 +7,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
+import com.android.brewr.model.coffee.Coffee
+import com.android.brewr.model.coffee.Hours
+import com.android.brewr.model.coffee.Review
 import com.android.brewr.model.location.Location
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -27,13 +30,19 @@ class MapScreenTest {
     uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     // Sample list of locations for testing
-    val sampleLocations =
+    val sampleCoffees =
         listOf(
-            Location(latitude = 46.5228, longitude = 6.6285, address = "Lausanne 1"),
-            Location(latitude = 46.5211, longitude = 6.6276, address = "Lausanne 2"))
+            Coffee(
+                "1",
+                "Coffee1",
+                Location(latitude = 46.5228, longitude = 6.6285, address = "Lausanne 1"),
+                4.5,
+                listOf(Hours("10", "20"), Hours("10", "20")),
+                listOf(Review("Lei", "good", 5.0)),
+                listOf("test.jpg")))
 
     // Set content to ExploreScreen
-    composeTestRule.setContent { MapScreen(listLocations = sampleLocations) }
+    composeTestRule.setContent { MapScreen(sampleCoffees) }
 
     // Handle location permission if prompted
     runBlocking { grantLocationPermission() }

--- a/app/src/androidTest/java/com/android/brewr/ui/overview/OverviewTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/overview/OverviewTest.kt
@@ -1,7 +1,18 @@
 package com.android.brewr.ui.overview
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.core.content.ContextCompat
+import androidx.test.rule.GrantPermissionRule
 import com.android.brewr.model.journey.BrewingMethod
 import com.android.brewr.model.journey.CoffeeOrigin
 import com.android.brewr.model.journey.CoffeeRate
@@ -15,17 +26,21 @@ import com.google.firebase.Timestamp
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class OverviewScreenTest {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var journeysRepository: JourneysRepository
   private lateinit var listJourneysViewModel: ListJourneysViewModel
+  @Mock lateinit var mockContext: Context
   private val journey =
       Journey(
           uid = "journey1",
@@ -41,9 +56,16 @@ class OverviewScreenTest {
 
   // Setup Compose Test Rule
   @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule
+  val fineLocationPermissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION)
+  @get:Rule
+  val coarseLocationPermissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION)
 
   @Before
   fun setUp() {
+    MockitoAnnotations.initMocks(this)
     navigationActions = mock(NavigationActions::class.java)
     journeysRepository = mock(JourneysRepository::class.java)
     listJourneysViewModel = spy(ListJourneysViewModel(journeysRepository))
@@ -51,6 +73,48 @@ class OverviewScreenTest {
     // Start the OverviewScreen composable for testing
     `when`(navigationActions.currentRoute()).thenReturn(Route.OVERVIEW)
     // composeTestRule.setContent { OverviewScreen(listJourneysViewModel,navigationActions) }
+
+  }
+
+  @Test
+  fun testPermissionGranted() {
+    // Mock ContextCompat.checkSelfPermission to return PERMISSION_GRANTED
+    whenever(
+            ContextCompat.checkSelfPermission(
+                mockContext, Manifest.permission.ACCESS_FINE_LOCATION))
+        .thenReturn(PackageManager.PERMISSION_GRANTED)
+
+    // Mock ContextCompat.checkSelfPermission to return PERMISSION_GRANTED
+    whenever(
+            ContextCompat.checkSelfPermission(
+                mockContext, Manifest.permission.ACCESS_COARSE_LOCATION))
+        .thenReturn(PackageManager.PERMISSION_GRANTED)
+
+    // Set up and run the Compose UI test
+    composeTestRule.setContent {
+      var permissionGranted by remember { mutableStateOf(false) }
+
+      // Launch permission check as in your real code
+      LaunchedEffect(Unit) {
+        permissionGranted =
+            ContextCompat.checkSelfPermission(
+                mockContext, Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    mockContext, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+                    PackageManager.PERMISSION_GRANTED
+      }
+
+      // Display content based on permissionGranted state
+      if (permissionGranted) {
+        Text("Permission Granted")
+      } else {
+        Text("Permission Denied")
+      }
+    }
+
+    // Verify that "Permission Granted" is displayed since permissions are mocked as granted
+    composeTestRule.onNodeWithText("Permission Granted").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/main/java/com/android/brewr/ui/overview/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Explore.kt
@@ -24,7 +24,7 @@ fun ExploreScreen(coffees: List<Coffee>) {
   var showBottomSheet by remember { mutableStateOf(false) }
 
   Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    MapScreen(coffees.map { it.location })
+    MapScreen(coffees)
 
     if (showBottomSheet) {
       ModalBottomSheet(onDismissRequest = { showBottomSheet = false }, sheetState = sheetState) {

--- a/app/src/main/java/com/android/brewr/ui/overview/Map.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Map.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.core.content.ContextCompat
-import com.android.brewr.model.location.Location
+import com.android.brewr.model.coffee.Coffee
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -26,7 +26,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import kotlinx.coroutines.tasks.await
 
 @Composable
-fun MapScreen(listLocations: List<Location>) {
+fun MapScreen(coffees: List<Coffee>) {
   val context = LocalContext.current
   var userLocation by remember { mutableStateOf<LatLng?>(null) }
   var permissionGranted by remember { mutableStateOf(false) }
@@ -64,23 +64,25 @@ fun MapScreen(listLocations: List<Location>) {
   Scaffold(
       content = { paddingValues ->
         val cameraPositionState = rememberCameraPositionState {
-          position = CameraPosition.fromLatLngZoom(userLocation ?: LatLng(37.7749, -122.4194), 10f)
+          position = CameraPosition.fromLatLngZoom(userLocation ?: LatLng(46.5197, 6.6323), 14f)
         }
 
         GoogleMap(
             modifier = Modifier.fillMaxSize().padding(paddingValues).testTag("mapScreen"),
             cameraPositionState = cameraPositionState) {
-              listLocations.forEach { location ->
+              coffees.forEach { coffee ->
                 Log.d(
                     "MapScreen",
-                    "Adding marker for ${location.address} at (${location.latitude}, ${location.longitude})")
+                    "Adding marker for ${coffee.location.address} at (${coffee.location.latitude}, ${coffee.location.longitude})")
                 Marker(
                     state =
                         remember {
-                          MarkerState(position = LatLng(location.latitude, location.longitude))
+                          MarkerState(
+                              position =
+                                  LatLng(coffee.location.latitude, coffee.location.longitude))
                         },
-                    title = location.address, // Use name as title for logging purposes
-                    snippet = "Lat: ${location.latitude}, Lng: ${location.longitude}")
+                    title = coffee.coffeeShopName,
+                    snippet = "Address: ${coffee.location.address}")
               }
 
               userLocation?.let {

--- a/app/src/main/java/com/android/brewr/ui/overview/Map.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Map.kt
@@ -1,12 +1,8 @@
 package com.android.brewr.ui.overview
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.pm.PackageManager
 import android.util.Log
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -14,7 +10,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.core.content.ContextCompat
 import com.android.brewr.model.coffee.Coffee
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.CameraPosition
@@ -30,9 +25,7 @@ fun MapScreen(coffees: List<Coffee>) {
   val context = LocalContext.current
   var userLocation by remember { mutableStateOf<LatLng?>(null) }
 
-  LaunchedEffect(Unit) {
-      userLocation = getCurrentLocation(context)
-  }
+  LaunchedEffect(Unit) { userLocation = getCurrentLocation(context) }
 
   Scaffold(
       content = { paddingValues ->

--- a/app/src/main/java/com/android/brewr/ui/overview/Map.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Map.kt
@@ -29,36 +29,9 @@ import kotlinx.coroutines.tasks.await
 fun MapScreen(coffees: List<Coffee>) {
   val context = LocalContext.current
   var userLocation by remember { mutableStateOf<LatLng?>(null) }
-  var permissionGranted by remember { mutableStateOf(false) }
-
-  val locationPermissionLauncher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.RequestMultiplePermissions(),
-          onResult = { permissions ->
-            permissionGranted =
-                permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
-                    permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
-          })
 
   LaunchedEffect(Unit) {
-    permissionGranted =
-        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
-            PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(
-                context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
-                PackageManager.PERMISSION_GRANTED
-
-    if (!permissionGranted) {
-      locationPermissionLauncher.launch(
-          arrayOf(
-              Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
-    }
-  }
-
-  LaunchedEffect(permissionGranted) {
-    if (permissionGranted) {
       userLocation = getCurrentLocation(context)
-    }
   }
 
   Scaffold(

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -21,8 +21,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
@@ -31,13 +31,12 @@ import com.android.brewr.model.coffee.Coffee
 import com.android.brewr.model.journey.ListJourneysViewModel
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Screen
-import com.android.brewr.ui.theme.Purple80
+import com.android.brewr.ui.theme.CoffeeBrown
+import com.android.brewr.ui.theme.LightBrown
 import com.android.brewr.utils.fetchNearbyCoffeeShops
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.tasks.await
-import com.android.brewr.ui.theme.CoffeeBrown
-import com.android.brewr.ui.theme.LightBrown
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -36,7 +36,10 @@ import com.android.brewr.ui.theme.LightBrown
 import com.android.brewr.utils.fetchNearbyCoffeeShops
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -80,11 +83,12 @@ fun OverviewScreen(
 
   LaunchedEffect(permissionGranted) {
     if (permissionGranted) {
-      fetchNearbyCoffeeShops(
-          coroutineScope,
-          context,
-          getCurrentLocation(context) ?: LatLng(46.5197, 6.6323),
-          onSuccess = { coffeeShops = it })
+      coroutineScope.launch {
+        val currentLocation =
+            withContext(Dispatchers.IO) { getCurrentLocation(context) } ?: LatLng(46.5197, 6.6323)
+        fetchNearbyCoffeeShops(
+            coroutineScope, context, currentLocation, onSuccess = { coffeeShops = it })
+      }
     }
   }
 

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -2,6 +2,7 @@ package com.android.brewr.ui.overview
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -31,7 +32,9 @@ import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Screen
 import com.android.brewr.ui.theme.Purple80
 import com.android.brewr.utils.fetchNearbyCoffeeShops
+import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.tasks.await
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
@@ -76,7 +79,7 @@ fun OverviewScreen(
   LaunchedEffect(permissionGranted) {
     if (permissionGranted) {
       fetchNearbyCoffeeShops(
-          coroutineScope, context, LatLng(46.5197, 6.6323), onSuccess = { coffeeShops = it })
+          coroutineScope, context, getCurrentLocation(context)?:LatLng(46.5197, 6.6323), onSuccess = { coffeeShops = it })
     }
   }
 
@@ -150,4 +153,15 @@ fun SubNavigationButton(text: String, isSelected: Boolean = false, onClick: () -
                   RoundedCornerShape(8.dp))
               .padding(8.dp)
               .testTag(text))
+}
+@SuppressLint("MissingPermission")
+private suspend fun getCurrentLocation(context: Context): LatLng? {
+    return try {
+        val locationClient = LocationServices.getFusedLocationProviderClient(context)
+        val location = locationClient.lastLocation.await()
+        location?.let { LatLng(it.latitude, it.longitude) }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        null
+    }
 }

--- a/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/Overview.kt
@@ -79,7 +79,10 @@ fun OverviewScreen(
   LaunchedEffect(permissionGranted) {
     if (permissionGranted) {
       fetchNearbyCoffeeShops(
-          coroutineScope, context, getCurrentLocation(context)?:LatLng(46.5197, 6.6323), onSuccess = { coffeeShops = it })
+          coroutineScope,
+          context,
+          getCurrentLocation(context) ?: LatLng(46.5197, 6.6323),
+          onSuccess = { coffeeShops = it })
     }
   }
 
@@ -154,14 +157,15 @@ fun SubNavigationButton(text: String, isSelected: Boolean = false, onClick: () -
               .padding(8.dp)
               .testTag(text))
 }
+
 @SuppressLint("MissingPermission")
 private suspend fun getCurrentLocation(context: Context): LatLng? {
-    return try {
-        val locationClient = LocationServices.getFusedLocationProviderClient(context)
-        val location = locationClient.lastLocation.await()
-        location?.let { LatLng(it.latitude, it.longitude) }
-    } catch (e: Exception) {
-        e.printStackTrace()
-        null
-    }
+  return try {
+    val locationClient = LocationServices.getFusedLocationProviderClient(context)
+    val location = locationClient.lastLocation.await()
+    location?.let { LatLng(it.latitude, it.longitude) }
+  } catch (e: Exception) {
+    e.printStackTrace()
+    null
+  }
 }

--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -1,11 +1,9 @@
 package com.android.brewr.utils
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
-import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.android.brewr.BuildConfig
 import com.android.brewr.model.coffee.Coffee
@@ -84,10 +82,7 @@ fun fetchNearbyCoffeeShops(
                                   review = review.text ?: "Undefined",
                                   rating = review.rating)
                             },
-                        //use this image to avoid using API to fetch photos as it is very expensive
-                        imagesUrls = listOf("https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain"),
-                        //imagesUrls = fetchAllPhotoUris(place, placesClient)
-                ))
+                        imagesUrls = fetchAllPhotoUris(place, placesClient)))
               }
             }
             if (coffeeShops.isNotEmpty()) {

--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -82,6 +82,9 @@ fun fetchNearbyCoffeeShops(
                                   review = review.text ?: "Undefined",
                                   rating = review.rating)
                             },
+                        // use this image to avoid using API to fetch photos as it is very expensive
+                        // imagesUrls =
+                        // listOf("https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain"),
                         imagesUrls = fetchAllPhotoUris(place, placesClient)))
               }
             }

--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -91,7 +91,9 @@ fun fetchNearbyCoffeeShops(
                                   review = review.text ?: "Undefined",
                                   rating = review.rating)
                             },
-                        imagesUrls = fetchAllPhotoUris(place, placesClient)))
+                        imagesUrls = listOf("https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain"),
+                        //imagesUrls = fetchAllPhotoUris(place, placesClient)
+                ))
               }
             }
             if (coffeeShops.isNotEmpty()) {

--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -83,13 +83,17 @@ fun fetchNearbyCoffeeShops(
                                   rating = review.rating)
                             },
                         // use this image to avoid using API to fetch photos as it is very expensive
-                        // imagesUrls =
-                        // listOf("https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain"),
+                        //                        imagesUrls =
+                        //                            listOf(
+                        //
+                        // "https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain")))
                         imagesUrls = fetchAllPhotoUris(place, placesClient)))
               }
             }
             if (coffeeShops.isNotEmpty()) {
-              Log.d("PlacesAPI", "Coffee shops founded: ${coffeeShops.size}")
+              Log.d(
+                  "PlacesAPI",
+                  "Coffee shops founded: ${coffeeShops.size} ${coffeeShops[0].coffeeShopName}")
             } else {
               Log.d("PlacesAPI", "No coffee shops found.")
             }
@@ -105,13 +109,15 @@ fun fetchNearbyCoffeeShops(
 }
 
 private suspend fun fetchAllPhotoUris(place: Place, placesClient: PlacesClient): List<String> {
-  return place.photoMetadatas?.map { metadata ->
+  val metadata = place.photoMetadatas?.get(0)
+  metadata?.let {
     val photoUriRequest =
-        FetchResolvedPhotoUriRequest.builder(metadata).setMaxWidth(500).setMaxHeight(300).build()
-
+        FetchResolvedPhotoUriRequest.builder(it).setMaxWidth(500).setMaxHeight(300).build()
     // Fetch the URI and wait for the result
-    placesClient.fetchResolvedPhotoUri(photoUriRequest).await()?.uri.toString()
-  } ?: emptyList() // If no photo metadata, return an empty list
+    val result = placesClient.fetchResolvedPhotoUri(photoUriRequest).await()?.uri.toString()
+    return listOf(result)
+  }
+  return emptyList()
 }
 
 private fun getHours(weekdayText: List<String>?): List<Hours> {

--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -37,13 +37,6 @@ fun fetchNearbyCoffeeShops(
     val apiKey = BuildConfig.MAPS_API_KEY
     Places.initialize(context, apiKey)
   }
-  if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) !=
-      PackageManager.PERMISSION_GRANTED) {
-    ActivityCompat.requestPermissions(
-        context as Activity,
-        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-        LOCATION_PERMISSION_REQUEST_CODE)
-  }
   val circle = CircularBounds.newInstance(currentLocation, radius)
   val type = listOf("cafe")
   // Specify the fields we want in the Place API response
@@ -91,6 +84,7 @@ fun fetchNearbyCoffeeShops(
                                   review = review.text ?: "Undefined",
                                   rating = review.rating)
                             },
+                        //use this image to avoid using API to fetch photos as it is very expensive
                         imagesUrls = listOf("https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain"),
                         //imagesUrls = fetchAllPhotoUris(place, placesClient)
                 ))

--- a/app/src/test/java/com/android/brewr/utils/FetchNearbyCoffeeShopsTest.kt
+++ b/app/src/test/java/com/android/brewr/utils/FetchNearbyCoffeeShopsTest.kt
@@ -139,23 +139,6 @@ class FetchNearbyCoffeeShopsTest {
   }
 
   @Test
-  fun fetchNearbyCoffeeShops_request_permission() {
-    every {
-      ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
-    } returns PackageManager.PERMISSION_DENIED
-    every { ActivityCompat.requestPermissions(any<Activity>(), any(), any()) } just Runs
-
-    fetchNearbyCoffeeShops(testScope, context, currentLocation, radius) {}
-
-    verify {
-      ActivityCompat.requestPermissions(
-          context as Activity,
-          arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-          LOCATION_PERMISSION_REQUEST_CODE)
-    }
-  }
-
-  @Test
   fun fetchNearbyCoffeeShops_fails() {
     // Simulate an API failure using Tasks.forException
     val apiException = Exception("API call failed")


### PR DESCRIPTION

This PR enables displaying real coffee shop data on the explore screen. The following files have been updated:

- FetchNearbyCoffeeShop.kt: Removed permission check logic.
- Map.kt: Removed permission check and updated the input argument type.
- Overview.kt: Added permission check, invoked fetchNearbyCoffeeShop, and passed data to the explore screen.
- Explore.kt: Passed data to MapScreen.

Additionally, the corresponding test files have been updated to align with the new permission check logic:
- e2eTest.kt
- MapScreenTest.kt
- OverviewTest.kt
- FetchNearbyCoffeeShopTest.kt

![Capture d'écran 2024-11-14 100343](https://github.com/user-attachments/assets/7c16d74b-27e5-4e8b-8663-f2acd5ae1835)
![Capture d'écran 2024-11-14 100415](https://github.com/user-attachments/assets/e3b18e6a-e1bf-4ff5-8d86-6d764221ad54)
