### PR TITLE
Fix/bug in journey record screen

### DIFF
--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -165,7 +165,6 @@ class E2ETest {
         .onNodeWithTag("inputJourneyDescription")
         .assertIsDisplayed()
         .performTextInput("Amazing Coffee Experience")
-    composeTestRule.onNodeWithTag("coffeeShopCheckRow").assertHasClickAction().performClick()
 
     composeTestRule.onNodeWithTag("inputCoffeeshopLocation").assertHasClickAction().performClick()
     composeTestRule.onNodeWithTag("inputCoffeeshopLocation").assertExists()

--- a/app/src/androidTest/java/com/android/brewr/ui/overview/AddJourneyScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/overview/AddJourneyScreenTest.kt
@@ -58,6 +58,26 @@ class AddJourneyScreenTest {
         .assertIsDisplayed()
         .performTextInput("Amazing Coffee Experience")
 
+    // Check if the location input field is displayed
+    composeTestRule.onNodeWithTag("coffeeShopCheckRow").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("coffeeShopCheckboxIcon", useUnmergedTree = true)
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("coffeeShopCheckText", useUnmergedTree = true)
+        .assertTextEquals("At a coffee shop")
+    // Check if the Coffee Shop Name input field displays
+    composeTestRule.onNodeWithTag("inputCoffeeshopLocation").assertIsDisplayed()
+
+    // Test the coffee shop checkbox interaction
+    composeTestRule.onNodeWithTag("coffeeShopCheckRow").assertHasClickAction().performClick()
+    // Assert that the text "At home" is displayed
+    composeTestRule
+        .onNodeWithTag("coffeeShopCheckText", useUnmergedTree = true)
+        .assertTextEquals("At home")
+    // Check if the Coffee Shop Name input field not display
+    composeTestRule.onNodeWithTag("inputCoffeeshopLocation").assertIsNotDisplayed()
+
     // Test the coffee shop checkbox interaction
     composeTestRule.onNodeWithTag("coffeeShopCheckRow").assertHasClickAction().performClick()
 

--- a/app/src/main/java/com/android/brewr/ui/overview/AddJourney.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/AddJourney.kt
@@ -128,7 +128,7 @@ fun AddJourneyScreen(
                       expanded = isYesSelected
                     },
                     coffeeshopExpanded = expanded,
-                    selectedLocation = selectedLocation,
+                   // selectedLocation = selectedLocation,
                     onSelectedLocationChange = { selectedLocation = it })
               }
 

--- a/app/src/main/java/com/android/brewr/ui/overview/AddJourney.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/AddJourney.kt
@@ -62,8 +62,8 @@ fun AddJourneyScreen(
   var coffeeRate by remember { mutableStateOf(CoffeeRate.DEFAULT) }
   val date by remember { mutableStateOf(Timestamp.now()) } // Using Firebase Timestamp for now
   val context = LocalContext.current
-  var expanded by remember { mutableStateOf(false) } // State for the dropdown menu
-  var isYesSelected by remember { mutableStateOf(false) }
+  var expanded by remember { mutableStateOf(true) } // State for the dropdown menu
+  var isYesSelected by remember { mutableStateOf(true) }
 
   val getImageLauncher =
       rememberLauncherForActivityResult(
@@ -128,7 +128,6 @@ fun AddJourneyScreen(
                       expanded = isYesSelected
                     },
                     coffeeshopExpanded = expanded,
-                   // selectedLocation = selectedLocation,
                     onSelectedLocationChange = { selectedLocation = it })
               }
 

--- a/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
@@ -127,7 +127,7 @@ fun EditJourneyScreen(
                     expanded = isYesSelected
                   },
                   coffeeshopExpanded = expanded,
-                  selectedLocation = selectedLocation,
+                  //selectedLocation = selectedLocation,
                   onSelectedLocationChange = { selectedLocation = it })
 
               // Coffee Origin Dropdown Menu
@@ -172,6 +172,7 @@ fun EditJourneyScreen(
                             coffeeRate = coffeeRate,
                             date = selectedDate)
                     listJourneysViewModel.updateJourney(updatedJourney)
+                      listJourneysViewModel.selectJourney(updatedJourney)
                     navigationActions.goBack()
                   },
                   modifier = Modifier.fillMaxWidth().testTag("journeySave")) {

--- a/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
@@ -61,10 +61,9 @@ fun EditJourneyScreen(
   val date by remember { mutableStateOf(task.date) }
 
   var expanded by remember {
-    mutableStateOf(selectedLocation.name.isNotEmpty())
+    mutableStateOf(false)
   } // State for the dropdown menu
-  var isYesSelected by remember { mutableStateOf(false) }
-
+  var isYesSelected by remember { mutableStateOf(selectedLocation.name !="At home") }
   val getImageLauncher =
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.GetContent(), onResult = { uri -> imageUri = uri })
@@ -127,7 +126,6 @@ fun EditJourneyScreen(
                     expanded = isYesSelected
                   },
                   coffeeshopExpanded = expanded,
-                  //selectedLocation = selectedLocation,
                   onSelectedLocationChange = { selectedLocation = it })
 
               // Coffee Origin Dropdown Menu
@@ -172,7 +170,7 @@ fun EditJourneyScreen(
                             coffeeRate = coffeeRate,
                             date = selectedDate)
                     listJourneysViewModel.updateJourney(updatedJourney)
-                      listJourneysViewModel.selectJourney(updatedJourney)
+                    listJourneysViewModel.selectJourney(updatedJourney)
                     navigationActions.goBack()
                   },
                   modifier = Modifier.fillMaxWidth().testTag("journeySave")) {

--- a/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
@@ -60,10 +60,8 @@ fun EditJourneyScreen(
   var coffeeRate by remember { mutableStateOf(task.coffeeRate) }
   val date by remember { mutableStateOf(task.date) }
 
-  var expanded by remember {
-    mutableStateOf(false)
-  } // State for the dropdown menu
-  var isYesSelected by remember { mutableStateOf(selectedLocation.name !="At home") }
+  var expanded by remember { mutableStateOf(false) } // State for the dropdown menu
+  var isYesSelected by remember { mutableStateOf(selectedLocation.name != "At home") }
   val getImageLauncher =
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.GetContent(), onResult = { uri -> imageUri = uri })

--- a/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
-import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
@@ -109,7 +109,6 @@ fun CoffeeShopCheckRow(
     isYesSelected: Boolean,
     onCheckChange: () -> Unit,
     coffeeshopExpanded: Boolean,
-    //selectedLocation: Location,
     onSelectedLocationChange: (Location) -> Unit
 ) {
   var showDropdown by remember { mutableStateOf(false) }
@@ -122,13 +121,13 @@ fun CoffeeShopCheckRow(
       verticalAlignment = Alignment.CenterVertically,
       modifier = Modifier.testTag("coffeeShopCheckRow").clickable { onCheckChange() }) {
         Icon(
-            imageVector = if (isYesSelected) Icons.Outlined.Check else Icons.Outlined.Close,
+            imageVector = if (isYesSelected) Icons.Outlined.Check else Icons.Outlined.Home,
             contentDescription = if (isYesSelected) "Checked" else "Unchecked",
             tint = Color.Black,
             modifier = Modifier.testTag("coffeeShopCheckboxIcon"))
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            text = "At a coffee shop",
+            text =  if (isYesSelected) "At a coffee shop" else "At home",
             color = Color.Black,
             modifier = Modifier.testTag("coffeeShopCheckText"))
       }
@@ -185,8 +184,8 @@ fun CoffeeShopCheckRow(
               }
         }
   }
-    else{
-        onSelectedLocationChange(Location())
+  else if (!isYesSelected) {
+    onSelectedLocationChange(Location())
   }
 }
 

--- a/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
@@ -109,7 +109,7 @@ fun CoffeeShopCheckRow(
     isYesSelected: Boolean,
     onCheckChange: () -> Unit,
     coffeeshopExpanded: Boolean,
-    selectedLocation: Location,
+    //selectedLocation: Location,
     onSelectedLocationChange: (Location) -> Unit
 ) {
   var showDropdown by remember { mutableStateOf(false) }
@@ -184,6 +184,9 @@ fun CoffeeShopCheckRow(
                 }
               }
         }
+  }
+    else{
+        onSelectedLocationChange(Location())
   }
 }
 

--- a/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
+++ b/app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Check
-import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
@@ -127,7 +127,7 @@ fun CoffeeShopCheckRow(
             modifier = Modifier.testTag("coffeeShopCheckboxIcon"))
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            text =  if (isYesSelected) "At a coffee shop" else "At home",
+            text = if (isYesSelected) "At a coffee shop" else "At home",
             color = Color.Black,
             modifier = Modifier.testTag("coffeeShopCheckText"))
       }
@@ -135,8 +135,8 @@ fun CoffeeShopCheckRow(
   if (coffeeshopExpanded) {
     ExposedDropdownMenuBox(
         expanded = showDropdown && locationSuggestions.isNotEmpty(),
-        onExpandedChange = { showDropdown = it } // Toggle dropdown visibility
-        ) {
+        onExpandedChange = { showDropdown = it }, // Toggle dropdown visibility
+        modifier = Modifier.testTag("exposedDropdownMenuBox")) {
           OutlinedTextField(
               value = locationQuery,
               onValueChange = {
@@ -183,8 +183,7 @@ fun CoffeeShopCheckRow(
                 }
               }
         }
-  }
-  else if (!isYesSelected) {
+  } else if (!isYesSelected) {
     onSelectedLocationChange(Location())
   }
 }


### PR DESCRIPTION


**Description:**
This PR addresses a bug in the application where changes to the coffee shop location were not reflected when editing journeys. Additionally, the coffee shop input field behavior was updated in both the Add and Edit screens to enhance the user experience.

**Changes Made:**
Bug Fix:

Fixed the issue where changes made to the coffee shop location were not saved or displayed correctly in the Edit Journey screen.
Behavior Updates:

Add Journey Screen:
If the user selects "At home" as the location, the text "At home" is displayed instead of a close icon for better clarity.
Edit Journey Screen:
The search bar is hidden by default.
Displays "At home" text if the journey was an at-home experience and "At a coffee shop" if it was a coffee shop experience.
Code Changes:

Modified logic in EditJourney.kt and JourneyComponents.kt to handle the location display dynamically.
Added fallback behavior to initialize the location to a default state if none is selected.
Updated the test cases in AddJourneyScreenTest.kt and EditJourneyScreenTest.kt to reflect the new behavior.
Files Updated:
app/src/main/java/com/android/brewr/ui/overview/AddJourney.kt
app/src/main/java/com/android/brewr/ui/overview/EditJourney.kt
app/src/main/java/com/android/brewr/ui/overview/JourneyComponents.kt
app/src/androidTest/java/com/android/brewr/ui/overview/AddJourneyScreenTest.kt
app/src/androidTest/java/com/android/brewr/ui/overview/EditJourneyScreenTest.kt

**Testing:**
Confirmed the display of "At home" and "At a coffee shop" text dynamically on both Add and Edit screens.
Ensured existing test cases pass and updated tests for the new behaviors.
Not implemented the end to end test that checks the changes made to the coffee shop location persist in the Edit Journey screen. It will be implemented through another end-to-end test.

**Screen Shot:**
![at a coffeeshop addscreeen](https://github.com/user-attachments/assets/83353fba-c668-43d1-b811-a755529ecf94)
**Default Addscreen**
![at home addscreen](https://github.com/user-attachments/assets/f26c6695-2223-4c7c-894d-04c9ae5fb259)
**Addscreen when the user clicks the coffeeshop check row**
![at coffeeshop edit](https://github.com/user-attachments/assets/86305618-487d-4de1-99eb-8094d9705bf1)
**Edit screen when the coffeeshop location was a coffeeshop**
![at home edit](https://github.com/user-attachments/assets/b7f3b1db-ecd7-4364-935a-bd8264902eb9)
**Edit screen when the coffeeshop location was at home**