### PR TITLE
develop/display-filter-opened-coffeeshop-in-explore-screen

### DIFF
--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -278,5 +278,31 @@ class E2ETest {
     composeTestRule.onNodeWithTag("coffeeImage:${sampleCoffees[1].id}").assertIsDisplayed()
 
        */
+
+  }
+
+  @Test
+  fun exploreScreenDropdownMenuIntegrationTest() {
+    // Go to the Explore screen
+    composeTestRule.onNodeWithTag("Explore").assertIsDisplayed().performClick()
+    composeTestRule.runOnIdle { navigationActions.navigateTo(EXPLORE) }
+    composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
+
+    // Open the bottom sheet
+    composeTestRule.onNodeWithTag("menuButton").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("exploreBottomSheet").assertIsDisplayed()
+
+    // Select "Curated" from the dropdown menu
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
+    composeTestRule.onNodeWithText("Curated").performClick()
+    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Curated")
+
+    // Select "Opened" from the dropdown menu
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
+    composeTestRule.onNodeWithText("Opened").performClick()
+    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Opened")
+
+    // Assert the "closed" message is displayed if the list is empty
+    composeTestRule.onNodeWithTag("noOpenCoffeeShopsMessage").assertExists()
   }
 }

--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -295,12 +295,12 @@ class E2ETest {
     // Select "Curated" from the dropdown menu
     composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
     composeTestRule.onNodeWithText("Curated").performClick()
-    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Curated")
+    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Curated Coffee Shops")
 
     // Select "Opened" from the dropdown menu
     composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
     composeTestRule.onNodeWithText("Opened").performClick()
-    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Opened")
+    composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Opened Coffee Shops")
 
     // Assert the "closed" message is displayed if the list is empty
     composeTestRule.onNodeWithTag("noOpenCoffeeShopsMessage").assertExists()

--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -250,11 +250,9 @@ class E2ETest {
         .assertIsDisplayed()
         .assertTextEquals("Nearby Coffee Shops")
 
-    // Verify the toggle button and switch to the curated list
-    composeTestRule.onNodeWithTag("toggleListButton").assertIsDisplayed().performClick()
-
-    // Verify the curated list title is displayed
-    composeTestRule.onNodeWithTag("listTitle").assertIsDisplayed().assertTextEquals("Curated List")
+    // Verify the dropdown menu functionality
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("dropdownMenu").assertIsDisplayed()
 
     // check the bottomSheet and coffee shop information existence
     composeTestRule.onNodeWithTag("bottomSheet").assertIsDisplayed().performTouchInput {

--- a/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/e2eTest.kt
@@ -286,18 +286,23 @@ class E2ETest {
     composeTestRule.runOnIdle { navigationActions.navigateTo(EXPLORE) }
     composeTestRule.onNodeWithTag("mapScreen").assertIsDisplayed()
 
+    // Clear the coffee list to simulate an empty state
+    composeTestRule.runOnIdle { coffeesViewModel.clearCoffees() }
     // Open the bottom sheet
     composeTestRule.onNodeWithTag("menuButton").assertIsDisplayed().performClick()
     composeTestRule.onNodeWithTag("exploreBottomSheet").assertIsDisplayed()
 
+    // Verify the dropdown menu opens
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("dropdownMenu").assertIsDisplayed()
+
     // Select "Curated" from the dropdown menu
-    composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
-    composeTestRule.onNodeWithText("Curated").performClick()
+    composeTestRule.onNodeWithText("Curated").assertExists().performClick()
     composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Curated Coffee Shops")
 
     // Select "Opened" from the dropdown menu
-    composeTestRule.onNodeWithTag("toggleDropdownMenu").performClick()
-    composeTestRule.onNodeWithText("Opened").performClick()
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithText("Opened").assertExists().performClick()
     composeTestRule.onNodeWithTag("listTitle").assertTextEquals("Opened Coffee Shops")
 
     // Assert the "closed" message is displayed if the list is empty

--- a/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
@@ -123,7 +123,12 @@ class CoffeeInformationScreenTest {
         composeTestRule
             .onNodeWithTag("button${review.authorName}")
             .assertTextEquals(
-                "- ${review.authorName}: \"${review.review}\" (${String.format("%.1f/5", review.rating)})")
+                "- ${review.authorName}: \"${review.review}\" (${
+                          String.format(
+                              "%.1f/5",
+                              review.rating
+                          )
+                      })")
       }
     }
     composeTestRule.onNodeWithTag("buttonWorst").assertExists().performClick()

--- a/app/src/androidTest/java/com/android/brewr/ui/explore/ExploreScreenComponentTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/explore/ExploreScreenComponentTest.kt
@@ -1,0 +1,42 @@
+package com.android.brewr.ui.explore
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExploreScreenComponentTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun toggleDropdownMenuDisplaysOptions() {
+    composeTestRule.setContent { ListToggleRow(selectedOption = "Nearby", onOptionSelected = {}) }
+
+    // Assert the dropdown button exists
+    composeTestRule.onNodeWithTag("toggleDropdownMenu").assertIsDisplayed().performClick()
+
+    // Assert dropdown options are displayed
+    composeTestRule.onNodeWithTag("dropdownMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dropdownMenuItemNearby").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dropdownMenuItemCurated").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("dropdownMenuItemOpened").assertIsDisplayed()
+  }
+
+  @Test
+  fun emptyCoffeeListDisplaysClosedMessage() {
+    composeTestRule.setContent { CoffeeList(coffees = emptyList(), onCoffeeClick = {}) }
+
+    // Assert the message for closed coffee shops is displayed
+    composeTestRule
+        .onNodeWithTag("noOpenCoffeeShopsMessage")
+        .assertIsDisplayed()
+        .assertTextEquals(
+            "Everywhere is closed! I guess Coffee will disturb your sleep at this time")
+  }
+}

--- a/app/src/main/java/com/android/brewr/model/coffee/CoffeesViewModel.kt
+++ b/app/src/main/java/com/android/brewr/model/coffee/CoffeesViewModel.kt
@@ -39,4 +39,15 @@ open class CoffeesViewModel : ViewModel() {
   fun addCoffees(coffeesList: List<Coffee>) {
     viewModelScope.launch { coffees_.value = coffeesList }
   }
+
+  /**
+   * Clears the current list of coffees.
+   *
+   * This method sets the coffees state to an empty list, effectively removing all coffee entries.
+   * It can be used to reset the coffee data or simulate scenarios where no coffees are available.
+   * This operation is performed within a coroutine scope to ensure thread safety.
+   */
+  fun clearCoffees() {
+    viewModelScope.launch { coffees_.value = emptyList() }
+  }
 }

--- a/app/src/main/java/com/android/brewr/model/coffee/CuratedCoffeeShopList.kt
+++ b/app/src/main/java/com/android/brewr/model/coffee/CuratedCoffeeShopList.kt
@@ -29,8 +29,8 @@ fun filterOpenCoffeeShops(coffeeShops: List<Coffee>): List<Coffee> {
   return coffeeShops.filter { coffee ->
     coffee.hours.any { hour ->
       try {
-        val openTime = LocalTime.parse(hour.open, DateTimeFormatter.ofPattern("h:mm a"))
-        val closeTime = LocalTime.parse(hour.close, DateTimeFormatter.ofPattern("h:mm a"))
+        val openTime = LocalTime.parse(hour.open, DateTimeFormatter.ofPattern("h:mm a"))
+        val closeTime = LocalTime.parse(hour.close, DateTimeFormatter.ofPattern("h:mm a"))
         currentTime.isAfter(openTime) && currentTime.isBefore(closeTime)
       } catch (e: Exception) {
         println("Invalid time for Coffee Shop: ${coffee.coffeeShopName}, Error: ${e.message}")

--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -38,7 +38,6 @@ fun ExploreScreen(coffeesViewModel: CoffeesViewModel, curatedCoffees: List<Coffe
 
   // Collect coffees list
   val coffees = coffeesViewModel.coffees.collectAsState().value
-  val filteredOpenedCoffees = filterOpenCoffeeShops(coffees) // Apply filtering for "Opened"
 
   // State for controlling the current view in the bottom sheet
   var showCoffeeInfos by remember { mutableStateOf(false) }
@@ -58,7 +57,7 @@ fun ExploreScreen(coffeesViewModel: CoffeesViewModel, curatedCoffees: List<Coffe
                 val listToShow =
                     when (selectedOption) {
                       "Curated" -> curatedCoffees
-                      "Opened" -> filteredOpenedCoffees
+                      "Opened" -> filterOpenCoffeeShops(coffees)
                       else -> coffees
                     }
 

--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -109,13 +110,19 @@ fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
             modifier = Modifier.align(Alignment.CenterVertically).testTag("listTitle"))
 
         Box {
-          Button(
+          TextButton(
               onClick = { expanded = true },
               colors = ButtonDefaults.buttonColors(containerColor = CoffeeBrown),
               shape = RoundedCornerShape(15.dp),
               modifier = Modifier.testTag("toggleDropdownMenu")) {
+                Icon(
+                    imageVector = Icons.Filled.Menu,
+                    contentDescription = "Choose View",
+                    tint = Color.White
+                )
+                Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = "Choose View",
+                    text = "Filter",
                     style = MaterialTheme.typography.bodySmall,
                     color = Color.White)
               }

--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -95,8 +95,16 @@ fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
   Row(
       modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("exploreListToggleRow"),
       horizontalArrangement = Arrangement.SpaceBetween) {
+        // Add " Coffee Shops" to selected option to match the test expectation
+        val displayText =
+            when (selectedOption) {
+              "Nearby" -> "Nearby Coffee Shops"
+              "Curated" -> "Curated Coffee Shops"
+              "Opened" -> "Opened Coffee Shops"
+              else -> "Nearby Coffee Shops"
+            }
         Text(
-            text = selectedOption,
+            text = displayText,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.align(Alignment.CenterVertically).testTag("listTitle"))
 

--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -118,8 +118,7 @@ fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
                 Icon(
                     imageVector = Icons.Filled.Menu,
                     contentDescription = "Choose View",
-                    tint = Color.White
-                )
+                    tint = Color.White)
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
                     text = "Filter",

--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -43,105 +43,92 @@ fun ExploreScreen(coffeesViewModel: CoffeesViewModel, curatedCoffees: List<Coffe
   // State for controlling the current view in the bottom sheet
   var showCoffeeInfos by remember { mutableStateOf(false) }
 
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        MapScreen(coffees)
+  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    MapScreen(coffees)
 
-        if (showBottomSheet) {
-            ModalBottomSheet(
-                onDismissRequest = { showBottomSheet = false },
-                sheetState = sheetState,
-                modifier = Modifier.testTag("exploreBottomSheet")
-            ) {
-                if (!showCoffeeInfos) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        ListToggleRow(selectedOption = selectedOption) { option ->
-                            selectedOption = option
-                        }
+    if (showBottomSheet) {
+      ModalBottomSheet(
+          onDismissRequest = { showBottomSheet = false },
+          sheetState = sheetState,
+          modifier = Modifier.testTag("exploreBottomSheet")) {
+            if (!showCoffeeInfos) {
+              Column(modifier = Modifier.fillMaxWidth()) {
+                ListToggleRow(selectedOption = selectedOption) { option -> selectedOption = option }
 
-                        val listToShow = when (selectedOption) {
-                            "Curated" -> curatedCoffees
-                            "Opened" -> filteredOpenedCoffees
-                            else -> coffees
-                        }
-
-                        CoffeeList(listToShow) {
-                            coffeesViewModel.selectCoffee(it)
-                            showCoffeeInfos = true
-                        }
+                val listToShow =
+                    when (selectedOption) {
+                      "Curated" -> curatedCoffees
+                      "Opened" -> filteredOpenedCoffees
+                      else -> coffees
                     }
-                } else {
-                    CoffeeInformationScreen(
-                        coffeesViewModel = coffeesViewModel,
-                        onBack = { showCoffeeInfos = false }
-                    )
+
+                CoffeeList(listToShow) {
+                  coffeesViewModel.selectCoffee(it)
+                  showCoffeeInfos = true
                 }
+              }
+            } else {
+              CoffeeInformationScreen(
+                  coffeesViewModel = coffeesViewModel, onBack = { showCoffeeInfos = false })
             }
-        }
-
-        ShowMenuButton { showBottomSheet = true }
-
-        LaunchedEffect(Unit) { coroutineScope.launch { sheetState.show() } }
+          }
     }
+
+    ShowMenuButton { showBottomSheet = true }
+
+    LaunchedEffect(Unit) { coroutineScope.launch { sheetState.show() } }
+  }
 }
 
 /**
  * A composable function that displays a row with a dropdown menu to allow users to toggle between
  * different list views such as "Nearby", "Curated", and "Opened".
  *
- * @param selectedOption A [String] representing the currently selected option (e.g., "Nearby", "Curated", "Opened").
- * @param onOptionSelected A callback function that is invoked when the user selects an option from the dropdown menu.
- *        The selected option is passed as a parameter to this function.
+ * @param selectedOption A [String] representing the currently selected option (e.g., "Nearby",
+ *   "Curated", "Opened").
+ * @param onOptionSelected A callback function that is invoked when the user selects an option from
+ *   the dropdown menu. The selected option is passed as a parameter to this function.
  */
 @Composable
 fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
+  var expanded by remember { mutableStateOf(false) }
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .testTag("exploreListToggleRow"),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("exploreListToggleRow"),
+      horizontalArrangement = Arrangement.SpaceBetween) {
         Text(
             text = selectedOption,
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .testTag("listTitle")
-        )
+            modifier = Modifier.align(Alignment.CenterVertically).testTag("listTitle"))
 
         Box {
-            Button(
-                onClick = { expanded = true },
-                colors = ButtonDefaults.buttonColors(containerColor = CoffeeBrown),
-                shape = RoundedCornerShape(15.dp),
-                modifier = Modifier.testTag("toggleDropdownMenu")
-            ) {
+          Button(
+              onClick = { expanded = true },
+              colors = ButtonDefaults.buttonColors(containerColor = CoffeeBrown),
+              shape = RoundedCornerShape(15.dp),
+              modifier = Modifier.testTag("toggleDropdownMenu")) {
                 Text(
                     text = "Choose View",
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color.White
-                )
-            }
+                    color = Color.White)
+              }
 
-            DropdownMenu(
-                expanded = expanded,
-                onDismissRequest = { expanded = false },
-                modifier = Modifier.testTag("dropdownMenu")
-            ) {
+          DropdownMenu(
+              expanded = expanded,
+              onDismissRequest = { expanded = false },
+              modifier = Modifier.testTag("dropdownMenu")) {
                 listOf("Nearby", "Curated", "Opened").forEach { option ->
-                    DropdownMenuItem(
-                        text = { Text(option) },
-                        onClick = {
-                            onOptionSelected(option)
-                            expanded = false
-                        }
-                    )
+                  DropdownMenuItem(
+                      text = { Text(option) },
+                      onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                      },
+                      modifier = Modifier.testTag("dropdownMenuItem$option"))
                 }
-            }
+              }
         }
-    }
+      }
 }
 
 /**
@@ -152,31 +139,24 @@ fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
  */
 @Composable
 fun CoffeeList(coffees: List<Coffee>, onCoffeeClick: (Coffee) -> Unit) {
-    if (coffees.isEmpty()) {
-        // Display a message when there are no coffee shops in the list
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = "Everywhere is closed! I guess Coffee will disturb your sleep at this time ",
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.Gray,
-                modifier = Modifier.testTag("noOpenCoffeeShopsMessage")
-            )
-        }
-    } else {
-        // Display the list of coffee shops
-        LazyColumn(modifier = Modifier.fillMaxHeight(0.9f).testTag("bottomSheet")) {
-            items(coffees) { coffee ->
-                CoffeeInformationCardScreen(coffee = coffee, onClick = { onCoffeeClick(coffee) })
-            }
-        }
+  if (coffees.isEmpty()) {
+    // Display a message when there are no coffee shops in the list
+    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+      Text(
+          text = "Everywhere is closed! I guess Coffee will disturb your sleep at this time",
+          style = MaterialTheme.typography.titleMedium,
+          color = Color.Gray,
+          modifier = Modifier.testTag("noOpenCoffeeShopsMessage"))
     }
+  } else {
+    // Display the list of coffee shops
+    LazyColumn(modifier = Modifier.fillMaxHeight(0.9f).testTag("bottomSheet")) {
+      items(coffees) { coffee ->
+        CoffeeInformationCardScreen(coffee = coffee, onClick = { onCoffeeClick(coffee) })
+      }
+    }
+  }
 }
-
 
 /**
  * A composable function that displays a menu button.

--- a/app/src/test/java/com/android/brewr/model/coffee/CuratedCoffeeShopListTest.kt
+++ b/app/src/test/java/com/android/brewr/model/coffee/CuratedCoffeeShopListTest.kt
@@ -83,11 +83,11 @@ class CuratedCoffeeShopListTest {
     val coffeeShops =
         listOf(
             createCoffeeShopWithHours(
-                "1", "Coffee Shop 1", listOf(Hours("Monday", "9:00 AM", "11:00 AM"))),
+                "1", "Coffee Shop 1", listOf(Hours("Monday", "9:00 AM", "11:00 AM"))),
             createCoffeeShopWithHours(
-                "2", "Coffee Shop 2", listOf(Hours("Monday", "11:00 AM", "12:00 PM"))),
+                "2", "Coffee Shop 2", listOf(Hours("Monday", "11:00 AM", "12:00 PM"))),
             createCoffeeShopWithHours(
-                "3", "Coffee Shop 3", listOf(Hours("Monday", "8:00 AM", "10:30 AM"))))
+                "3", "Coffee Shop 3", listOf(Hours("Monday", "8:00 AM", "10:30 AM"))))
 
     val result = filterOpenCoffeeShops(coffeeShops)
 
@@ -107,11 +107,11 @@ class CuratedCoffeeShopListTest {
     val coffeeShops =
         listOf(
             createCoffeeShopWithHours(
-                "1", "Coffee Shop 1", listOf(Hours("Monday", "9:00 AM", "Invalid Time"))),
+                "1", "Coffee Shop 1", listOf(Hours("Monday", "9:00 AM", "Invalid Time"))),
             createCoffeeShopWithHours(
-                "2", "Coffee Shop 2", listOf(Hours("Monday", "Invalid Time", "12:00 PM"))),
+                "2", "Coffee Shop 2", listOf(Hours("Monday", "Invalid Time", "12:00 PM"))),
             createCoffeeShopWithHours(
-                "3", "Coffee Shop 3", listOf(Hours("Monday", "9:00 AM", "11:00 AM"))))
+                "3", "Coffee Shop 3", listOf(Hours("Monday", "9:00 AM", "11:00 AM"))))
 
     val result = filterOpenCoffeeShops(coffeeShops)
     println("Filtered Result: ${result.size}")
@@ -126,7 +126,7 @@ class CuratedCoffeeShopListTest {
         coffeeShopName = name,
         location = Location(0.0, 0.0, "Test Address"),
         rating = rating,
-        hours = listOf(Hours("Monday", "9:00 AM", "5:00 PM")),
+        hours = listOf(Hours("Monday", "9:00 AM", "5:00 PM")),
         reviews = emptyList(),
         imagesUrls = emptyList())
   }


### PR DESCRIPTION
This PR introduces significant enhancements to the ExploreScreen by replacing the toggle button with a more user-friendly dropdown menu for switching between "Nearby", "Curated", and "Opened" coffee lists. Additionally, it includes updates to the ExploreScreen logic, list formatting, and e2e tests to ensure seamless functionality and user experience.

Its linked issue is : [Closes #<issue_number_if_applicable>](https://github.com/BrewR-EPFL/BrewR/issues/141)

Key Changes :
- Dropdown Menu for List Toggle :

   1. Replaced the toggle button with a dropdown menu in the ExploreScreen for better flexibility and consistency.
   2. Added a new ListToggleRow composable to dynamically handle user selections of "Nearby", "Curated", and "Opened" lists.
   3. Updated list titles to append "Coffee Shops" to the selected option text for clarity.

- Dynamic Coffee List Display :

   1. Implemented logic to display coffee lists based on the selected dropdown option :
      * Nearby : Displays all coffee shops.
      * Curated : Displays curated coffee shops sorted by ratings.
      * Opened : Displays only open coffee shops based on current time.

- Empty Coffee List Message :

   1. Added a fallback message, "Everywhere is closed! I guess Coffee will disturb your sleep at this time," to display when no open coffee shops are available.
   2. Introduced a clearCoffees method in CoffeesViewModel to reset the list of coffees to an empty state.
   3. Documented the clearCoffees method for improved code clarity and maintainability.

- E2E and Integration Tests :

   1. Enhanced end-to-end tests (E2ETest) to align with the updated dropdown menu functionality :
      * Verified dropdown menu interactions, including selecting "Nearby", "Curated", and "Opened".
      * Checked list title updates dynamically based on the selected dropdown option.
      * Validated empty coffee list scenarios by leveraging the new clearCoffees method
   2. Added a new unit test for ExploreScreen components : 
      * Verified the dropdown menu options and their visibility.
      * Ensured the fallback message is displayed for empty coffee lists.
      * Enhanced test tags to improve UI testing reliability and maintainability

These changes improve user experience by providing a more intuitive way to toggle between lists.
The added test tags enhance UI testing capabilities, ensuring better test reliability.

![image](https://github.com/user-attachments/assets/9fef94d9-94d7-48fe-a4f3-770453b0f5aa)
shows the opened coffeeshop
![image](https://github.com/user-attachments/assets/69a9744d-81f5-4633-9a29-b01cc0b56692)
shows the dropdownmenu with TextIcon


