### PR TITLE
Develop/user private list screen

### DIFF
--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserMainProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserMainProfileScreenTest.kt
@@ -49,7 +49,7 @@ class UserMainProfileScreenTest {
     composeTestRule.onNodeWithTag("User Profile Photo").assertIsDisplayed()
 
     // Test clicking unimplemented feature buttons
-    composeTestRule.onNodeWithTag("Preference button").performClick()
+    composeTestRule.onNodeWithTag("Favorite button").performClick()
     composeTestRule.onNodeWithTag("Notification button").performClick()
     composeTestRule.onNodeWithTag("TBD button").performClick()
     composeTestRule.onNodeWithTag("anything").performClick()

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -7,7 +7,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.verify
+import org.mockito.Mockito.verify
 
 class UserPrivateListScreenTest {
 
@@ -23,12 +23,17 @@ class UserPrivateListScreenTest {
   @Test
   fun userPrivateListScreen_displaysComponents() {
     composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
-
     composeTestRule.onNodeWithTag("UserPrivateListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("privateList").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("coffeeImage:1").performClick()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed().performClick()
+  }
+
+  @Test
+  fun userPrivateListScreen_goBackButton() {
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
+    composeTestRule.onNodeWithTag("goBackButton").performClick()
     verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -7,6 +7,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 
 class UserPrivateListScreenTest {
 
@@ -28,5 +29,6 @@ class UserPrivateListScreenTest {
     composeTestRule.onNodeWithTag("privateList").assertIsDisplayed()
     composeTestRule.onNodeWithTag("coffeeImage:1").performClick()
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed().performClick()
+    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -1,12 +1,14 @@
-package com.android.brewr.ui.userProfile
+package com.android.brewr.ui.UserProfile
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.android.brewr.ui.navigation.NavigationActions
+import com.android.brewr.ui.userProfile.UserPrivateListScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 
 class UserPrivateListScreenTest {
 
@@ -16,7 +18,7 @@ class UserPrivateListScreenTest {
   @Before
   fun setUp() {
     // Mock NavController
-    navigationActions = mock()
+    navigationActions = mock(NavigationActions::class.java)
   }
 
   @Test
@@ -33,5 +35,6 @@ class UserPrivateListScreenTest {
   fun userPrivateListScreen_goBackButton() {
     composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
     composeTestRule.onNodeWithTag("goBackButton").performClick()
+    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -1,0 +1,32 @@
+package com.android.brewr.ui.userProfile
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.android.brewr.ui.navigation.NavigationActions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class UserPrivateListScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navigationActions: NavigationActions
+
+  @Before
+  fun setUp() {
+    // Mock NavController
+    navigationActions = mock(NavigationActions::class.java)
+  }
+
+  @Test
+  fun userPrivateListScreen_displaysComponents() {
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("UserPrivateListScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("privateList").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("coffeeImage:1").performClick()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed().performClick()
+  }
+}

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -3,13 +3,10 @@ package com.android.brewr.ui.userProfile
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.android.brewr.ui.navigation.NavigationActions
-import com.android.brewr.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
 
 class UserPrivateListScreenTest {
 

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -3,11 +3,13 @@ package com.android.brewr.ui.userProfile
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.android.brewr.ui.navigation.NavigationActions
+import com.android.brewr.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 
 class UserPrivateListScreenTest {
 
@@ -17,7 +19,8 @@ class UserPrivateListScreenTest {
   @Before
   fun setUp() {
     // Mock NavController
-    navigationActions = mock(NavigationActions::class.java)
+    navigationActions = mock()
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.USER_PRIVATE_LIST)
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -20,7 +20,6 @@ class UserPrivateListScreenTest {
   fun setUp() {
     // Mock NavController
     navigationActions = mock()
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.USER_PRIVATE_LIST)
   }
 
   @Test
@@ -37,6 +36,5 @@ class UserPrivateListScreenTest {
   fun userPrivateListScreen_goBackButton() {
     composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
     composeTestRule.onNodeWithTag("goBackButton").performClick()
-    verify(navigationActions).goBack()
   }
 }

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.android.brewr.model.coffee.CoffeesViewModel
 import com.android.brewr.ui.navigation.NavigationActions
-import com.android.brewr.ui.navigation.Screen
 import com.android.brewr.ui.userProfile.UserPrivateListScreen
 import org.junit.Before
 import org.junit.Rule
@@ -19,7 +18,6 @@ class UserPrivateListScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var coffeesViewModel: CoffeesViewModel
 
-
   @Before
   fun setUp() {
     // Mock NavController
@@ -29,7 +27,7 @@ class UserPrivateListScreenTest {
 
   @Test
   fun userPrivateListScreen_displaysComponents() {
-    composeTestRule.setContent { UserPrivateListScreen(navigationActions,coffeesViewModel) }
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions, coffeesViewModel) }
     composeTestRule.onNodeWithTag("UserPrivateListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("privateList").assertIsDisplayed()
@@ -39,7 +37,7 @@ class UserPrivateListScreenTest {
 
   @Test
   fun userPrivateListScreen_goBackButton() {
-    composeTestRule.setContent { UserPrivateListScreen(navigationActions,coffeesViewModel) }
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions, coffeesViewModel) }
     composeTestRule.onNodeWithTag("goBackButton").performClick()
     verify(navigationActions).goBack()
   }

--- a/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/UserProfile/UserPrivateListScreenTest.kt
@@ -2,28 +2,34 @@ package com.android.brewr.ui.UserProfile
 
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.android.brewr.model.coffee.CoffeesViewModel
 import com.android.brewr.ui.navigation.NavigationActions
+import com.android.brewr.ui.navigation.Screen
 import com.android.brewr.ui.userProfile.UserPrivateListScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 class UserPrivateListScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
   private lateinit var navigationActions: NavigationActions
+  private lateinit var coffeesViewModel: CoffeesViewModel
+
 
   @Before
   fun setUp() {
     // Mock NavController
     navigationActions = mock(NavigationActions::class.java)
+    coffeesViewModel = spy(CoffeesViewModel::class.java)
   }
 
   @Test
   fun userPrivateListScreen_displaysComponents() {
-    composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions,coffeesViewModel) }
     composeTestRule.onNodeWithTag("UserPrivateListScreen").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("privateList").assertIsDisplayed()
@@ -33,7 +39,7 @@ class UserPrivateListScreenTest {
 
   @Test
   fun userPrivateListScreen_goBackButton() {
-    composeTestRule.setContent { UserPrivateListScreen(navigationActions) }
+    composeTestRule.setContent { UserPrivateListScreen(navigationActions,coffeesViewModel) }
     composeTestRule.onNodeWithTag("goBackButton").performClick()
     verify(navigationActions).goBack()
   }

--- a/app/src/main/java/com/android/brewr/MainActivity.kt
+++ b/app/src/main/java/com/android/brewr/MainActivity.kt
@@ -20,6 +20,7 @@ import com.android.brewr.model.journey.ListJourneysViewModel
 import com.android.brewr.model.user.UserViewModel
 import com.android.brewr.resources.C
 import com.android.brewr.ui.authentication.SignInScreen
+import com.android.brewr.ui.explore.CoffeeInformationScreen
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Route
 import com.android.brewr.ui.navigation.Screen
@@ -64,6 +65,7 @@ fun BrewRApp() {
       viewModel(factory = ListJourneysViewModel.Factory)
   val userViewModel: UserViewModel = viewModel(factory = UserViewModel.Factory)
   val coffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
+  val privateCoffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
 
   NavHost(navController, Route.AUTH) {
     navigation(
@@ -99,7 +101,12 @@ fun BrewRApp() {
         startDestination = Screen.USERPROFILE,
         route = Route.USER_PROFILE,
     ) {
-      composable(Screen.USER_PRIVATE_LIST) { UserPrivateListScreen(navigationActions) }
+      composable(Screen.USER_PRIVATE_LIST) {
+        UserPrivateListScreen(navigationActions, privateCoffeesViewModel)
+      }
+      composable(Screen.USER_PRIVATE_LIST_INFOS) {
+        CoffeeInformationScreen(privateCoffeesViewModel, onBack = { navigationActions.goBack() })
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/brewr/MainActivity.kt
+++ b/app/src/main/java/com/android/brewr/MainActivity.kt
@@ -29,6 +29,7 @@ import com.android.brewr.ui.overview.JourneyRecordScreen
 import com.android.brewr.ui.overview.OverviewScreen
 import com.android.brewr.ui.theme.BrewRAppTheme
 import com.android.brewr.ui.userProfile.UserMainProfileScreen
+import com.android.brewr.ui.userProfile.UserPrivateListScreen
 import com.google.firebase.FirebaseApp
 import com.google.firebase.auth.FirebaseAuth
 
@@ -92,6 +93,13 @@ fun BrewRApp() {
       composable(Screen.EDIT_JOURNEY) {
         EditJourneyScreen(listJourneysViewModel, navigationActions)
       }
+    }
+
+    navigation(
+      startDestination = Screen.USERPROFILE,
+      route = Route.USER_PROFILE,
+    ) {
+      composable(Screen.USERPRIVATELIST) { UserPrivateListScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/brewr/MainActivity.kt
+++ b/app/src/main/java/com/android/brewr/MainActivity.kt
@@ -96,8 +96,8 @@ fun BrewRApp() {
     }
 
     navigation(
-      startDestination = Screen.USERPROFILE,
-      route = Route.USER_PROFILE,
+        startDestination = Screen.USERPROFILE,
+        route = Route.USER_PROFILE,
     ) {
       composable(Screen.USERPRIVATELIST) { UserPrivateListScreen(navigationActions) }
     }

--- a/app/src/main/java/com/android/brewr/MainActivity.kt
+++ b/app/src/main/java/com/android/brewr/MainActivity.kt
@@ -99,7 +99,7 @@ fun BrewRApp() {
         startDestination = Screen.USERPROFILE,
         route = Route.USER_PROFILE,
     ) {
-      composable(Screen.USERPRIVATELIST) { UserPrivateListScreen(navigationActions) }
+      composable(Screen.USER_PRIVATE_LIST) { UserPrivateListScreen(navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
@@ -19,7 +19,7 @@ object Screen {
   const val OVERVIEW = "Overview Screen"
   const val ADD_JOURNEY = "Add Journey Screen"
   const val USERPROFILE = "User Profile Screen"
-  const val USERPRIVATELIST = "User Private List Screen"
+  const val USER_PRIVATE_LIST = "User Private List Screen"
   const val JOURNEY_RECORD = "Journey Screen"
   const val EDIT_JOURNEY = "Edit Journey Screen"
   const val EXPLORE = "coffees explore screen"

--- a/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
@@ -10,6 +10,7 @@ object Route {
   const val OVERVIEW = "Overview"
   const val AUTH = "Auth"
   const val ADD_JOURNEY = "Add Journey"
+  const val USER_PROFILE = "User Profile"
 }
 
 object Screen {
@@ -18,6 +19,7 @@ object Screen {
   const val OVERVIEW = "Overview Screen"
   const val ADD_JOURNEY = "Add Journey Screen"
   const val USERPROFILE = "User Profile Screen"
+  const val USERPRIVATELIST = "User Private List Screen"
   const val JOURNEY_RECORD = "Journey Screen"
   const val EDIT_JOURNEY = "Edit Journey Screen"
   const val EXPLORE = "coffees explore screen"

--- a/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/brewr/ui/navigation/NavigationActions.kt
@@ -20,6 +20,7 @@ object Screen {
   const val ADD_JOURNEY = "Add Journey Screen"
   const val USERPROFILE = "User Profile Screen"
   const val USER_PRIVATE_LIST = "User Private List Screen"
+  const val USER_PRIVATE_LIST_INFOS = "User Private List Screen INFO"
   const val JOURNEY_RECORD = "Journey Screen"
   const val EDIT_JOURNEY = "Edit Journey Screen"
   const val EXPLORE = "coffees explore screen"

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
@@ -131,7 +131,7 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
               ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
-                      onClick = { navigationActions.navigateTo(Screen.USERPRIVATELIST) },
+                      onClick = { navigationActions.navigateTo(Screen.USER_PRIVATE_LIST) },
                       Modifier.testTag("Favorite button")) {
                         Icon(
                             imageVector = Icons.Default.Favorite, contentDescription = "Preference")

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
@@ -131,9 +131,7 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
               ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
-                      onClick = {
-                          navigationActions.navigateTo(Screen.USERPRIVATELIST)
-                      },
+                      onClick = { navigationActions.navigateTo(Screen.USERPRIVATELIST) },
                       Modifier.testTag("Favorite button")) {
                         Icon(
                             imageVector = Icons.Default.Favorite, contentDescription = "Preference")

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
@@ -46,6 +46,7 @@ import coil.request.ImageRequest
 import com.android.brewr.model.user.UserViewModel
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Route
+import com.android.brewr.ui.navigation.Screen
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 
@@ -154,6 +155,7 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
                       onClick = {
+                          navigationActions.navigateTo(Screen.USERPRIVATELIST)
                         Toast.makeText(context, NOT_YET_IMPLEMENTED, Toast.LENGTH_SHORT).show()
                       },
                       Modifier.testTag("TBD button")) {

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
@@ -155,7 +155,7 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
                       onClick = {
-                          navigationActions.navigateTo(Screen.USERPRIVATELIST)
+                        navigationActions.navigateTo(Screen.USERPRIVATELIST)
                         Toast.makeText(context, NOT_YET_IMPLEMENTED, Toast.LENGTH_SHORT).show()
                       },
                       Modifier.testTag("TBD button")) {

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserMainProfile.kt
@@ -132,13 +132,13 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
                       onClick = {
-                        Toast.makeText(context, NOT_YET_IMPLEMENTED, Toast.LENGTH_SHORT).show()
+                          navigationActions.navigateTo(Screen.USERPRIVATELIST)
                       },
-                      Modifier.testTag("Preference button")) {
+                      Modifier.testTag("Favorite button")) {
                         Icon(
                             imageVector = Icons.Default.Favorite, contentDescription = "Preference")
                       }
-                  Text("Preference")
+                  Text("Favorite")
                 }
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
@@ -155,7 +155,6 @@ fun UserMainProfileScreen(userViewModel: UserViewModel, navigationActions: Navig
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                   IconButton(
                       onClick = {
-                        navigationActions.navigateTo(Screen.USERPRIVATELIST)
                         Toast.makeText(context, NOT_YET_IMPLEMENTED, Toast.LENGTH_SHORT).show()
                       },
                       Modifier.testTag("TBD button")) {

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
@@ -1,0 +1,111 @@
+package com.android.brewr.ui.userProfile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.brewr.model.coffee.Coffee
+import com.android.brewr.model.coffee.CoffeesViewModel
+import com.android.brewr.model.coffee.Hours
+import com.android.brewr.model.coffee.Review
+import com.android.brewr.model.location.Location
+import com.android.brewr.ui.explore.CoffeeInformationScreen
+import com.android.brewr.ui.explore.CoffeeList
+import com.android.brewr.ui.navigation.NavigationActions
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun UserPrivateListScreen(navigationActions: NavigationActions){
+    val coffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
+    var showCoffeeInfos by remember { mutableStateOf(false) }
+
+    val mockCoffee =
+        Coffee(
+            "1",
+            coffeeShopName = "Café tranquille",
+            Location(
+                latitude = 48.87847905807652,
+                longitude = 2.3562626423266946,
+                address = "147 Rue du Faubourg Saint-Denis, 75010 Paris, France"),
+            rating = 4.9,
+            hours =
+            listOf(
+                Hours("Monday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Tuesday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Wednesday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Thursday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Friday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Saturday", open = "8:00 AM", close = "5:00 PM"),
+                Hours("Sunday", open = "8:00 AM", close = "5:00 PM")
+            ),
+            reviews =
+            listOf(
+                Review("Pablo", "Best coffee in the 10th arrondissement of Paris", 5.0),
+                Review("Thomas", "The staff is super friendly. Love their cappuccino!", 4.9),
+                Review("Claire", "Great spot to catch up with friends over a latte.", 4.8),
+                Review("Nicolas", "Delicious coffee, but seating is a bit limited.", 4.3),
+                Review("Alice", "Quiet and cozy, perfect for working in the morning.", 4.5),
+                Review("Camille", "Would come back just for the flat white!", 4.6)
+            ),
+            imagesUrls =
+            listOf(
+                "https://firebasestorage.googleapis.com/v0/b/brewr-epfl.appspot.com/o/images%2F2023-09-29.jpg?alt=media&token=eaaa9dbf-f402-4d12-b5ac-7c5589231a35"))
+    coffeesViewModel.addCoffees(listOf(mockCoffee))
+    Scaffold(
+        modifier = Modifier.fillMaxSize().testTag("UserPrivateListScreen"),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("User private list")
+                },
+                modifier = Modifier.testTag("topBar"),
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier =  Modifier.testTag("goBackButton")
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp).padding(paddingValues),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (!showCoffeeInfos){
+                    CoffeeList(listOf(mockCoffee)){
+                        coffeesViewModel.selectCoffee(it)
+                        showCoffeeInfos=true
+                    }
+                }
+                else{
+                    CoffeeInformationScreen(
+                        coffeesViewModel = coffeesViewModel, onBack = { showCoffeeInfos = false })
+                }
+            }
+
+        }
+    )
+}

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
@@ -29,6 +29,16 @@ import com.android.brewr.ui.explore.CoffeeList
 import com.android.brewr.ui.navigation.NavigationActions
 import com.android.brewr.ui.navigation.Screen
 
+/**
+ * Displays the user's private coffee list screen.
+ *
+ * This composable is responsible for showing a list of private coffee entries associated with the
+ * user. It interacts with the provided `CoffeesViewModel` to fetch and manage the data. Navigation
+ * to other screens is handled via the `navigationActions` parameter.
+ *
+ * @param navigationActions Handles navigation events to other screens.
+ * @param coffeesViewModel Provides data and business logic related to private coffee entries.
+ */
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 fun UserPrivateListScreen(

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
@@ -20,21 +20,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.brewr.model.coffee.Coffee
 import com.android.brewr.model.coffee.CoffeesViewModel
 import com.android.brewr.model.coffee.Hours
 import com.android.brewr.model.coffee.Review
 import com.android.brewr.model.location.Location
-import com.android.brewr.ui.explore.CoffeeInformationScreen
 import com.android.brewr.ui.explore.CoffeeList
 import com.android.brewr.ui.navigation.NavigationActions
+import com.android.brewr.ui.navigation.Screen
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun UserPrivateListScreen(navigationActions: NavigationActions) {
-  val coffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
-  var showCoffeeInfos by remember { mutableStateOf(false) }
+fun UserPrivateListScreen(
+    navigationActions: NavigationActions,
+    coffeesViewModel: CoffeesViewModel
+) {
+  var showPrivateCoffeeInfos by remember { mutableStateOf(false) }
 
   val mockCoffee =
       Coffee(
@@ -90,14 +91,13 @@ fun UserPrivateListScreen(navigationActions: NavigationActions) {
             modifier =
                 Modifier.fillMaxSize().testTag("privateList").padding(16.dp).padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp)) {
-              if (!showCoffeeInfos) {
+              if (!showPrivateCoffeeInfos) {
                 CoffeeList(listOf(mockCoffee)) {
                   coffeesViewModel.selectCoffee(it)
-                  showCoffeeInfos = true
+                  showPrivateCoffeeInfos = true
                 }
               } else {
-                CoffeeInformationScreen(
-                    coffeesViewModel = coffeesViewModel, onBack = { showCoffeeInfos = false })
+                navigationActions.navigateTo(Screen.USER_PRIVATE_LIST_INFOS)
               }
             }
       })

--- a/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
+++ b/app/src/main/java/com/android/brewr/ui/userProfile/UserPrivateList.kt
@@ -32,80 +32,73 @@ import com.android.brewr.ui.navigation.NavigationActions
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
-fun UserPrivateListScreen(navigationActions: NavigationActions){
-    val coffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
-    var showCoffeeInfos by remember { mutableStateOf(false) }
+fun UserPrivateListScreen(navigationActions: NavigationActions) {
+  val coffeesViewModel: CoffeesViewModel = viewModel(factory = CoffeesViewModel.Factory)
+  var showCoffeeInfos by remember { mutableStateOf(false) }
 
-    val mockCoffee =
-        Coffee(
-            "1",
-            coffeeShopName = "Café tranquille",
-            Location(
-                latitude = 48.87847905807652,
-                longitude = 2.3562626423266946,
-                address = "147 Rue du Faubourg Saint-Denis, 75010 Paris, France"),
-            rating = 4.9,
-            hours =
-            listOf(
-                Hours("Monday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Tuesday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Wednesday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Thursday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Friday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Saturday", open = "8:00 AM", close = "5:00 PM"),
-                Hours("Sunday", open = "8:00 AM", close = "5:00 PM")
-            ),
-            reviews =
-            listOf(
-                Review("Pablo", "Best coffee in the 10th arrondissement of Paris", 5.0),
-                Review("Thomas", "The staff is super friendly. Love their cappuccino!", 4.9),
-                Review("Claire", "Great spot to catch up with friends over a latte.", 4.8),
-                Review("Nicolas", "Delicious coffee, but seating is a bit limited.", 4.3),
-                Review("Alice", "Quiet and cozy, perfect for working in the morning.", 4.5),
-                Review("Camille", "Would come back just for the flat white!", 4.6)
-            ),
-            imagesUrls =
-            listOf(
-                "https://firebasestorage.googleapis.com/v0/b/brewr-epfl.appspot.com/o/images%2F2023-09-29.jpg?alt=media&token=eaaa9dbf-f402-4d12-b5ac-7c5589231a35"))
-    coffeesViewModel.addCoffees(listOf(mockCoffee))
-    Scaffold(
-        modifier = Modifier.fillMaxSize().testTag("UserPrivateListScreen"),
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text("User private list")
-                },
-                modifier = Modifier.testTag("topBar"),
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier =  Modifier.testTag("goBackButton")
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                            contentDescription = "Back"
-                        )
-                    }
+  val mockCoffee =
+      Coffee(
+          "1",
+          coffeeShopName = "Café tranquille",
+          Location(
+              latitude = 48.87847905807652,
+              longitude = 2.3562626423266946,
+              address = "147 Rue du Faubourg Saint-Denis, 75010 Paris, France"),
+          rating = 4.9,
+          hours =
+              listOf(
+                  Hours("Monday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Tuesday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Wednesday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Thursday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Friday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Saturday", open = "8:00 AM", close = "5:00 PM"),
+                  Hours("Sunday", open = "8:00 AM", close = "5:00 PM")),
+          reviews =
+              listOf(
+                  Review("Pablo", "Best coffee in the 10th arrondissement of Paris", 5.0),
+                  Review("Thomas", "The staff is super friendly. Love their cappuccino!", 4.9),
+                  Review("Claire", "Great spot to catch up with friends over a latte.", 4.8),
+                  Review("Nicolas", "Delicious coffee, but seating is a bit limited.", 4.3),
+                  Review("Alice", "Quiet and cozy, perfect for working in the morning.", 4.5),
+                  Review("Camille", "Would come back just for the flat white!", 4.6)),
+          imagesUrls =
+              listOf(
+                  "https://firebasestorage.googleapis.com/v0/b/brewr-epfl.appspot.com/o/images%2F2023-09-29.jpg?alt=media&token=eaaa9dbf-f402-4d12-b5ac-7c5589231a35"))
+  // To be changed later with a get user private list function
+  val privateList = listOf(mockCoffee)
+
+  coffeesViewModel.addCoffees(privateList)
+  Scaffold(
+      modifier = Modifier.fillMaxSize().testTag("UserPrivateListScreen"),
+      topBar = {
+        TopAppBar(
+            title = { Text("User private list") },
+            modifier = Modifier.testTag("topBar"),
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("goBackButton")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                        contentDescription = "Back")
+                  }
+            })
+      },
+      content = { paddingValues ->
+        Column(
+            modifier =
+                Modifier.fillMaxSize().testTag("privateList").padding(16.dp).padding(paddingValues),
+            verticalArrangement = Arrangement.spacedBy(8.dp)) {
+              if (!showCoffeeInfos) {
+                CoffeeList(listOf(mockCoffee)) {
+                  coffeesViewModel.selectCoffee(it)
+                  showCoffeeInfos = true
                 }
-            )
-        },
-        content = { paddingValues ->
-            Column(
-                modifier = Modifier.fillMaxSize().padding(16.dp).padding(paddingValues),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                if (!showCoffeeInfos){
-                    CoffeeList(listOf(mockCoffee)){
-                        coffeesViewModel.selectCoffee(it)
-                        showCoffeeInfos=true
-                    }
-                }
-                else{
-                    CoffeeInformationScreen(
-                        coffeesViewModel = coffeesViewModel, onBack = { showCoffeeInfos = false })
-                }
+              } else {
+                CoffeeInformationScreen(
+                    coffeesViewModel = coffeesViewModel, onBack = { showCoffeeInfos = false })
+              }
             }
-
-        }
-    )
+      })
 }


### PR DESCRIPTION
**Corresponding Issue:https://github.com/BrewR-EPFL/BrewR/issues/144**

Implement a private list feature within the user profile screen. This list will display coffee shops that the user has manually added from the explore screen. It allows users to quickly access and view details about their favorite coffee shops.

The following composable have been created:

- UserPrivateList.kt: This screen is designed to run a function that retrieves coffee shops and displays them as a private list. However, since the function hasn't been implemented yet, a mockCoffeeShop list is being used temporarily.
- UserPrivateListScreenTest.kt: Contains tests for the components of the UserPrivateListScreen

The following composable have been modified:

- MainActivity.kt: Added a navigation rule for UserPrivateListScreen.
- NavigationActions.kt: Introduced a route and screen definition for UserPrivateListScreen.
- UserMainProfile.kt: Updated a button to navigate to UserPrivateListScreen.

The following test tags have been added for testing:

- Scaffold: testTag("UserPrivateListScreen")
- TopAppBar: testTag("topBar")
- IconButton: testTag("goBackButton")
- content of lists: testTag("privateList")

![Screenshot_20241205_185402](https://github.com/user-attachments/assets/18a1b4fd-d4e1-4440-93f9-29944f92556b)
