### PR TITLE
feat(explore): highlight selected dropdown option and improve UX

### DIFF
--- a/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
+++ b/app/src/main/java/com/android/brewr/ui/explore/Explore.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.brewr.model.coffee.Coffee
 import com.android.brewr.model.coffee.CoffeesViewModel
@@ -138,9 +139,26 @@ fun ListToggleRow(selectedOption: String, onOptionSelected: (String) -> Unit) {
               modifier = Modifier.testTag("dropdownMenu")) {
                 listOf("Nearby", "Curated", "Opened").forEach { option ->
                   DropdownMenuItem(
-                      text = { Text(option) },
+                      text = {
+                        Row( // Wrap the content to include the checkmark
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween) {
+                              Text(
+                                  text = option,
+                                  fontWeight =
+                                      if (selectedOption == option) FontWeight.Bold
+                                      else FontWeight.Normal, // Highlight selected
+                                  modifier = Modifier.weight(1f))
+                              if (selectedOption == option) {
+                                Text(
+                                    text = "✓", // Add checkmark
+                                    fontWeight = FontWeight.Bold,
+                                    color = CoffeeBrown)
+                              }
+                            }
+                      },
                       onClick = {
-                        onOptionSelected(option)
+                        onOptionSelected(option) // Update selected option
                         expanded = false
                       },
                       modifier = Modifier.testTag("dropdownMenuItem$option"))


### PR DESCRIPTION
This PR improves the user experience on the Explore Screen by enhancing the dropdown filter menu. The changes visually highlight the currently selected option with bold text and a checkmark (✓), ensuring clarity for the user

Its linked issue : https://github.com/BrewR-EPFL/BrewR/issues/179

Changes Made :

* Added visual highlighting for selected options :
   - A checkmark (✓) next to the currently selected option.
Improved UX:

* Ensures users can easily identify the current filter in the dropdown list.
* Provides better feedback for user interactions.

![screenshot 2024-12-17 235156](https://github.com/user-attachments/assets/5688290f-c382-43d5-b297-fc0904cfcbc0)