### PR TITLE
test: fix a test bug in CoffeeInformationTest.kt

### DIFF
--- a/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -97,7 +98,7 @@ class CoffeeShopInformationScreenTest {
         .assertTextEquals(mockCoffeeShop.location.name)
     composeTestRule
         .onNodeWithTag(
-            "coffeeShopHour${LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }}")
+            "coffeeShopHour${LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }}").performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals(
             "${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].day}: ${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].open} - ${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].close}")

--- a/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
+++ b/app/src/androidTest/java/com/android/brewr/ui/explore/CoffeeInformationTest.kt
@@ -98,7 +98,8 @@ class CoffeeShopInformationScreenTest {
         .assertTextEquals(mockCoffeeShop.location.name)
     composeTestRule
         .onNodeWithTag(
-            "coffeeShopHour${LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }}").performScrollTo()
+            "coffeeShopHour${LocalDate.now().dayOfWeek.name.lowercase().replaceFirstChar { it.uppercase() }}")
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals(
             "${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].day}: ${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].open} - ${mockCoffeeShop.hours[LocalDate.now().dayOfWeek.value - 1].close}")


### PR DESCRIPTION
**Corresponding Issue** : https://github.com/BrewR-EPFL/BrewR/issues/186

This PR addresses an issue in CoffeeInformationTest.kt, where the displayAllComponentsValidCoffee test failed the SonarCloud check due to the Small Phone API 34 emulator.

The following file has been updated:

- CoffeeInformationTest.kt: I added a **.performScrollTo()** in line 101 for **displayAllComponentsValidCoffee()**