### PR TITLE
Change fetch coffee shop number to 20 and get image of coffee shop

### DIFF
--- a/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
+++ b/app/src/main/java/com/android/brewr/utils/FetchNearbyCoffeeShops.kt
@@ -162,7 +162,7 @@ fun fetchNearbyCoffeeShops(
   val request =
       SearchNearbyRequest.builder(circle, placeFields)
           .setIncludedTypes(type)
-          .setMaxResultCount(1)
+          .setMaxResultCount(20)
           .build()
   // Check if location permissions are granted
   if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
@@ -193,20 +193,21 @@ fun fetchNearbyCoffeeShops(
                               },
                           // use this image to avoid using API to fetch photos as it is very
                           // expensive
-                          imagesUrls =
-                              listOf(
-                                  "https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain")))
-                  // imagesUrls = fetchAllPhotoUris(place, placesClient)))
+                          //                          imagesUrls =
+                          //                              listOf(
+                          //
+                          // "https://th.bing.com/th/id/OIP.gNiGdodNdn2Bck61_x18dAHaFi?rs=1&pid=ImgDetMain")))
+                          imagesUrls = fetchAllPhotoUris(place, placesClient)))
                 }
-                if (coffeeShops.isNotEmpty()) {
-                  Log.d(
-                      "PlacesAPI",
-                      "Coffee shops founded: ${coffeeShops.size} ${coffeeShops[0].coffeeShopName}")
-                } else {
-                  Log.d("PlacesAPI", "No coffee shops found.")
-                }
-                onSuccess(coffeeShops)
               }
+              if (coffeeShops.isNotEmpty()) {
+                Log.d(
+                    "PlacesAPI",
+                    "Coffee shops founded: ${coffeeShops.size} ${coffeeShops[0].coffeeShopName}")
+              } else {
+                Log.d("PlacesAPI", "No coffee shops found.")
+              }
+              onSuccess(coffeeShops)
             }
           }
           .addOnFailureListener { exception ->


### PR DESCRIPTION
Corresponding Issue:https://github.com/BrewR-EPFL/BrewR/issues/190

This PR introduces a modification to the fetch functionality for nearby coffee shops(set to 20). Previously, the number of coffee shops was limited to one, and images were not retrieved during the development phase to minimize usage of the Google Places API.